### PR TITLE
[Config] Add support for accessing the config singleton in different lexical scopes

### DIFF
--- a/bin/jazzy
+++ b/bin/jazzy
@@ -12,4 +12,4 @@ end
 
 require 'jazzy'
 
-Jazzy::DocBuilder.build(Jazzy::Config.parse!)
+Jazzy::DocBuilder.build(Jazzy::Config.instance = Jazzy::Config.parse!)

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -103,5 +103,35 @@ module Jazzy
 
       config
     end
+
+    #-------------------------------------------------------------------------#
+
+    # @!group Singleton
+
+    # @return [Config] the current config instance creating one if needed.
+    #
+    def self.instance
+      @instance ||= new
+    end
+
+    # Sets the current config instance. If set to nil the config will be
+    # recreated when needed.
+    #
+    # @param  [Config, Nil] the instance.
+    #
+    # @return [void]
+    #
+    class << self
+      attr_writer :instance
+    end
+
+    # Provides support for accessing the configuration instance in other
+    # scopes.
+    #
+    module Mixin
+      def config
+        Config.instance
+      end
+    end
   end
 end


### PR DESCRIPTION
@jpsim this will allow making `pod spec document` and `pod lib document` to be much much easier.
