### PR TITLE
Set the default encoding to UTF-8.

### DIFF
--- a/lib/jazzy.rb
+++ b/lib/jazzy.rb
@@ -1,2 +1,4 @@
 require 'jazzy/config'
 require 'jazzy/doc_builder'
+
+Encoding.default_external = 'UTF-8'


### PR DESCRIPTION
After making myself a little shell script to run on build of a scheme in Xcode, it would always fail on me, even though running it from the terminal worked fine. Setting the default encoding to UTF-8 seems to fix this issue.

Reference: https://github.com/berkshelf/berkshelf-api/issues/112 (near the bottom)
It's an encoding thing, notice how the JSON parser is trying to use US-ASCII as it's encoding. As of ruby 1.9 the encoding for JSON parser is explicit so you can either add this to the berks executable:
Encoding.default_external = "UTF-8"