### PR TITLE
Better exception when Xcode not installed in standard location

### DIFF
--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -47,8 +47,7 @@ module Jazzy
     def self.run_sourcekitten(arguments)
       unless Pathname('/Applications/Xcode.app').exist?
         raise 'Xcode must be installed (or symlinked) at ' \
-        '/Applications/Xcode.app for jazzy to be able to work. ' \
-        'See https://github.com/realm/jazzy/issues/144 for more info.'
+        '/Applications/Xcode.app for jazzy to be able to work.'
       end
       bin_path = Pathname(__FILE__).parent + 'sourcekitten/sourcekitten'
       command = "#{bin_path} #{(arguments).join(' ')}"

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -45,6 +45,11 @@ module Jazzy
 
     # Run sourcekitten with given arguments and return STDOUT
     def self.run_sourcekitten(arguments)
+      unless Pathname('/Applications/Xcode.app').exist?
+        raise 'Xcode must be installed (or symlinked) at ' \
+        '/Applications/Xcode.app for jazzy to be able to work. ' \
+        'See https://github.com/realm/jazzy/issues/144 for more info.'
+      end
       bin_path = Pathname(__FILE__).parent + 'sourcekitten/sourcekitten'
       command = "#{bin_path} #{(arguments).join(' ')}"
       output = `#{command}`


### PR DESCRIPTION
This avoids SourceKitten to fail to launch and crash when Xcode is not installed in `/Applications/Xcode.app` (as SourceKitten would fail to load `libclang.dylib` in such cases)

See also #144 and [this comment](https://github.com/realm/jazzy/issues/159#issuecomment-73424745) on #159 