### PR TITLE
RubyGem install: fix SourceKitten symlinks

### DIFF
--- a/lib/jazzy/sourcekitten/Rakefile
+++ b/lib/jazzy/sourcekitten/Rakefile
@@ -5,10 +5,10 @@ task :prepare do
   Dir.glob('*.framework').each do |fw|
     p fw
     Dir.chdir(fw) do
-      basename = File.basename(fw, '*.framework')
-      version = Dir.glob('Versions/*').sort.last
+      basename = File.basename(fw, ".framework")
+      FileUtils.rm(basename)
 
-      File.symlink(version,                        'Versions/Current')
+      File.symlink("A",                            "Versions/Current")
       File.symlink("Versions/Current/#{basename}", "#{basename}")
       File.symlink("Versions/Current/Resources",   "Resources")
       File.symlink("Versions/Current/Modules",     "Modules")

--- a/lib/jazzy/sourcekitten/Rakefile
+++ b/lib/jazzy/sourcekitten/Rakefile
@@ -5,13 +5,13 @@ task :prepare do
   Dir.glob('*.framework').each do |fw|
     p fw
     Dir.chdir(fw) do
-      basename = File.basename(fw, ".framework")
+      basename = File.basename(fw, '.framework')
       FileUtils.rm(basename)
 
-      File.symlink("A",                            "Versions/Current")
+      File.symlink('A',                            'Versions/Current')
       File.symlink("Versions/Current/#{basename}", "#{basename}")
-      File.symlink("Versions/Current/Resources",   "Resources")
-      File.symlink("Versions/Current/Modules",     "Modules")
+      File.symlink('Versions/Current/Resources',   'Resources')
+      File.symlink('Versions/Current/Modules',     'Modules')
     end
   end
 end


### PR DESCRIPTION
I built the gem locally using below and tested by running jazzy on a sample project.

```bash
gem build jazzy.gemspec
sudo gem install ./jazzy-0.1.1.gem
```

Now we have (which matches what SourceKitten creates standalone)

```bash
$ pwd
/Library/Ruby/Gems/2.0.0/gems/jazzy-0.1.1/lib/jazzy/SourceKitten/SourceKittenFramework.framework
$ tree -L 3
.
├── Modules -> Versions/Current/Modules
├── Resources -> Versions/Current/Resources
├── SourceKittenFramework -> Versions/Current/SourceKittenFramework
└── Versions
    ├── A
    │   ├── Frameworks
    │   ├── Modules
    │   ├── Resources
    │   └── SourceKittenFramework
    └── Current -> A

8 directories, 2 files
```

Two things to note:

- Line 8: `.framework` extension was not being removed from name
- Line 9: Since the symlinks fail to download, the destination file is swapped in place of the symlink, so we have a duplicate of the file. To allow us to once again create the symlink with the proper name, remove the duplicate file first

Ref: https://github.com/realm/jazzy/issues/159