### PR TITLE
Use Menlo font for code outside of README as well

### DIFF
--- a/lib/jazzy/assets/css/jazzy.css.scss
+++ b/lib/jazzy/assets/css/jazzy.css.scss
@@ -1,5 +1,6 @@
 $doc_coverage_color: #999;
 $content_wrapper_width: 980px;
+$code-font: 12px Menlo, monospace;
 
 html, body, div, span, h1, h3, h4, p, a, code, em, img, ul, li, table, tbody, tr, td {
   background: transparent;
@@ -97,6 +98,7 @@ html, body, div, span, h1, h3, h4, p, a, code, em, img, ul, li, table, tbody, tr
     font-size: 1.4em;
     word-break: break-all;
     > code {
+      font: $code-font;
       display: inline-block;
     }
   }
@@ -149,6 +151,7 @@ html, body, div, span, h1, h3, h4, p, a, code, em, img, ul, li, table, tbody, tr
   .section .declaration {
     margin-top: 21px;
     code {
+      font: $code-font;
       color: rgba(128, 128, 128, 1);
       margin-bottom: 15px;
       padding-bottom: 6px;


### PR DESCRIPTION
Closes https://github.com/realm/jazzy/issues/137#issuecomment-68619733.

Tested on Safari & Firefox.

### Before

![before](https://cloud.githubusercontent.com/assets/2666961/6403909/b85a1968-bde0-11e4-995f-24736678a414.png)

### After

![after](https://cloud.githubusercontent.com/assets/2666961/6403911/be7a3490-bde0-11e4-8aef-e1d8a8f55be4.png)
