### PR TITLE
[SourceKitten] No longer count initializers with parameters as undocumented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ##### Bug Fixes
 
-* No longer count initializers with parameters as undocumented.
+* No longer count initializers with parameters as undocumented.  
   [JP Simard](https://github.com/jpsim)
   [#183](https://github.com/realm/jazzy/issues/183)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 
 ##### Bug Fixes
 
-* None.
+* No longer count initializers with parameters as undocumented.
+  [JP Simard](https://github.com/jpsim)
+  [#183](https://github.com/realm/jazzy/issues/183)
 
 ## 0.1.2
 

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -40,6 +40,8 @@ module Jazzy
       end
 
       def param?
+        # SourceKit strangely categorizes initializer parameters as local
+        # variables, so both kinds represent a parameter in jazzy.
         kind == 'source.lang.swift.decl.var.parameter' ||
           kind == 'source.lang.swift.decl.var.local'
       end

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -31,8 +31,17 @@ module Jazzy
         kind == 'source.lang.swift.syntaxtype.comment.mark'
       end
 
+      def should_document?
+        declaration? && !param?
+      end
+
       def declaration?
         kind =~ /^source\.lang\.swift\.decl\..*/
+      end
+
+      def param?
+        kind == 'source.lang.swift.decl.var.parameter' ||
+          kind == 'source.lang.swift.decl.var.local'
       end
 
       def self.overview

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -143,7 +143,7 @@ module Jazzy
         if declaration.type.mark? && doc['key.name'].start_with?('MARK: ')
           current_mark = SourceMark.new(doc['key.name'])
         end
-        next unless declaration.type.declaration?
+        next unless declaration.type.should_document?
 
         unless declaration.type.name
           raise 'Please file an issue on ' \


### PR DESCRIPTION
Fixes #183.

Initializers with parameters would be counted additional times for each undocumented parameter (which SourceKit oddly categorizes as local variables instead of parameters). This meant that initializers showed up in `/undocumented.txt` and affected code coverage percentage.

Care to take a look @segiddins and @jessesquires?