### PR TITLE
No longer count undocumented externally declared tokens as undocumented.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,6 @@
 * No longer count initializers with parameters as undocumented.  
   [JP Simard](https://github.com/jpsim)
   [#183](https://github.com/realm/jazzy/issues/183)
-* No longer count undocumented externally declared tokens as undocumented.
-  [JP Simard](https://github.com/jpsim)
-  [#188](https://github.com/realm/jazzy/issues/188)
-* Fixed `--source-directory` CLI option.
-  [JP Simard](https://github.com/jpsim)
-  [#177](https://github.com/realm/jazzy/issues/177)
 
 * No longer crash when a token is missing a USR.  
   [JP Simard](https://github.com/jpsim)
@@ -30,6 +24,14 @@
 * Fixed encoding issues in some environments.  
   [James Barrow](https://github.com/Baza207)
   [#152](https://github.com/realm/jazzy/issues/152)
+
+* No longer count undocumented externally declared tokens as undocumented.
+  [JP Simard](https://github.com/jpsim)
+  [#188](https://github.com/realm/jazzy/issues/188)
+
+* Fixed `--source-directory` CLI option.
+  [JP Simard](https://github.com/jpsim)
+  [#177](https://github.com/realm/jazzy/issues/177)
 
 
 ## 0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 * No longer count initializers with parameters as undocumented.  
   [JP Simard](https://github.com/jpsim)
   [#183](https://github.com/realm/jazzy/issues/183)
+* No longer count undocumented externally declared tokens as undocumented.
+  [JP Simard](https://github.com/jpsim)
+  [#188](https://github.com/realm/jazzy/issues/188)
+* Fixed `--source-directory` CLI option.
+  [JP Simard](https://github.com/jpsim)
+  [#177](https://github.com/realm/jazzy/issues/177)
 
 * No longer crash when a token is missing a USR.  
   [JP Simard](https://github.com/jpsim)

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -52,9 +52,10 @@ module Jazzy
         if podspec = options.podspec
           stdout = PodspecDocumenter.new(podspec).sourcekitten_output
         else
-          stdout = SourceKitten.run_sourcekitten(
-            ['doc'] + options.xcodebuild_arguments,
-          )
+	  stdout = Dir.chdir(Config.instance.source_directory) do
+	    arguments = ['doc'] + options.xcodebuild_arguments
+	    SourceKitten.run_sourcekitten(arguments)
+	  end
         end
         unless $?.success?
           warn 'Please pass in xcodebuild arguments using -x'

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -52,10 +52,10 @@ module Jazzy
         if podspec = options.podspec
           stdout = PodspecDocumenter.new(podspec).sourcekitten_output
         else
-	  stdout = Dir.chdir(Config.instance.source_directory) do
-	    arguments = ['doc'] + options.xcodebuild_arguments
-	    SourceKitten.run_sourcekitten(arguments)
-	  end
+          stdout = Dir.chdir(Config.instance.source_directory) do
+            arguments = ['doc'] + options.xcodebuild_arguments
+            SourceKitten.run_sourcekitten(arguments)
+          end
         end
         unless $?.success?
           warn 'Please pass in xcodebuild arguments using -x'

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -87,7 +87,11 @@ module Jazzy
     end
 
     def self.process_undocumented_token(doc, declaration)
-      @undocumented_tokens << doc
+      source_directory = Config.instance.source_directory.to_s
+      filepath = doc['key.filepath']
+      if !filepath || filepath.start_with?(source_directory)
+	@undocumented_tokens << doc
+      end
       return nil if !documented_child?(doc) && @skip_undocumented
       make_default_doc_info(declaration)
     end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -90,7 +90,7 @@ module Jazzy
       source_directory = Config.instance.source_directory.to_s
       filepath = doc['key.filepath']
       if !filepath || filepath.start_with?(source_directory)
-	@undocumented_tokens << doc
+        @undocumented_tokens << doc
       end
       return nil if !documented_child?(doc) && @skip_undocumented
       make_default_doc_info(declaration)


### PR DESCRIPTION
And fixed `--source-directory` CLI option.

Fixes #188 and #177. /cc @segiddins 