### PR TITLE
Added a 'Troubeshooting' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,10 @@ To install jazzy, run `[sudo] gem install jazzy` from your command line.
 Run `jazzy` from your command line. Run `jazzy -h` for a list of additional
 options.
 
-### Troubleshooting
+#### Troubleshooting
 
 ***Only extensions are listed in the documentation.***
-By default, jazzy will only create documentation for public methods and classes. If you want to generate documentation for all of your files, make sure you set the `--min-acl` flag to `internal` or `private`.
-
-```sh
-jazzy --output /path/to/output --source-directory /path/to/src --min-acl internal
-```
+By default, jazzy only documents public declarations. To generate documentation for declarations with a lower accessibility level (internal or private), please set the `--min-acl` flag to `internal` or `private`.
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ To install jazzy, run `[sudo] gem install jazzy` from your command line.
 Run `jazzy` from your command line. Run `jazzy -h` for a list of additional
 options.
 
+### Troubleshooting
+
+***Only extensions are listed in the documentation.***
+By default, jazzy will only create documentation for public methods and classes. If you want to generate documentation for all of your files, make sure you set the `--min-acl` flag to `internal` or `private`.
+
+```sh
+jazzy --output /path/to/output --source-directory /path/to/src --min-acl internal
+```
+
 ### Development
 
 jazzy is composed of two parts: the parser ([sourcekitten][sourcekitten],

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ To install jazzy, run `[sudo] gem install jazzy` from your command line.
 Run `jazzy` from your command line. Run `jazzy -h` for a list of additional
 options.
 
-#### Troubleshooting
+### Troubleshooting
 
-***Only extensions are listed in the documentation.***
+#### Only extensions are listed in the documentation.
 By default, jazzy only documents public declarations. To generate documentation for declarations with a lower accessibility level (internal or private), please set the `--min-acl` flag to `internal` or `private`.
 
 ### Development


### PR DESCRIPTION
Some issues seem to come up repeatedly and could maybe be avoided by having a small *troubleshooting* section in the README. 

As an example, I've added one question relating to the `--min-acl` parameter which is often the reason why users only see extensions when everything else seems to be running well.