### PR TITLE
Set Dash width to 100%

### DIFF
--- a/lib/jazzy/assets/css/jazzy.css.scss
+++ b/lib/jazzy/assets/css/jazzy.css.scss
@@ -416,7 +416,7 @@ html.dash {
     width: $content_wrapper_width;
     margin-left: 0;
     border: none;
-    width: auto;
+    width: 100%;
     top: 0;
     padding-bottom: 0;
   }


### PR DESCRIPTION
`width:auto` seems to cause issues like in the screenshot below. `width:100%` seems to work much better. Haven't tested it extensively though...

![screen shot 2015-07-23 at 04 23 32](https://cloud.githubusercontent.com/assets/1445635/8841132/ae556d7a-30f2-11e5-8af7-2d894390e004.png)
