### PR TITLE
make assets directory configurable enabling the use of own css / js

### DIFF
--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -31,6 +31,7 @@ module Jazzy
     attr_accessor :source_directory
     attr_accessor :excluded_files
     attr_accessor :template_directory
+    attr_accessor :assets_directory
 
     def initialize
       PodspecDocumenter.configure(self, Dir['*.podspec{,.json}'].first)
@@ -47,6 +48,7 @@ module Jazzy
       self.source_directory = Pathname.pwd
       self.excluded_files = []
       self.template_directory = Pathname(__FILE__).parent + 'templates'
+      self.assets_directory = Pathname(__FILE__).parent + '../../lib/jazzy/assets/'
     end
 
     def podspec=(podspec)
@@ -172,6 +174,11 @@ module Jazzy
         opt.on('t', '--template-directory DIRPATH', 'The directory that ' \
                'contains the mustache templates to use') do |template_directory|
           config.template_directory = Pathname(template_directory)
+        end
+
+        opt.on('--assets-directory DIRPATH', 'The directory that ' \
+               'contains the assets (CSS, JS, images)  to use') do |assets_directory|
+          config.assets_directory = Pathname(assets_directory)
         end
 
         opt.on('--readme FILEPATH',

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -48,7 +48,7 @@ module Jazzy
       self.source_directory = Pathname.pwd
       self.excluded_files = []
       self.template_directory = Pathname(__FILE__).parent + 'templates'
-      self.assets_directory = Pathname(__FILE__).parent + '../../lib/jazzy/assets/'
+      self.assets_directory = Pathname(__FILE__).parent + 'assets'
     end
 
     def podspec=(podspec)

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -178,7 +178,7 @@ module Jazzy
 
         opt.on('--assets-directory DIRPATH', 'The directory that ' \
                'contains the assets (CSS, JS, images)  to use') do |assets_directory|
-          config.assets_directory = Pathname(assets_directory)
+          config.assets_directory = Pathname(assets_directory).expand_path
         end
 
         opt.on('--readme FILEPATH',

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -160,7 +160,6 @@ module Jazzy
     end
 
     def self.copy_assets(destination)
-      # origin = Pathname(__FILE__).parent + '../../lib/jazzy/assets/.'
       origin = options.assets_directory;
       FileUtils.cp_r(origin, destination)
       Pathname.glob(destination + 'css/**/*.scss').each do |scss|

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -160,7 +160,8 @@ module Jazzy
     end
 
     def self.copy_assets(destination)
-      origin = Pathname(__FILE__).parent + '../../lib/jazzy/assets/.'
+      # origin = Pathname(__FILE__).parent + '../../lib/jazzy/assets/.'
+      origin = options.assets_directory;
       FileUtils.cp_r(origin, destination)
       Pathname.glob(destination + 'css/**/*.scss').each do |scss|
         contents = scss.read


### PR DESCRIPTION
Thanks for creating the possibility to pass a template directory. However, if you want to use different assets than the ones provided, you should also be able to be flexible with this. I created a parameter `--`-`--assets_directory`, that enables you to provide a different asset location. 

Please check backward compatibility and if everything is fine, you could merge this.