### PR TITLE
--exclude now works with relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Master
+
+##### Breaking
+
+* None.
+
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
+* `--exclude` now works properly if its argument is a relative path.
+  [pcantrell](https://github.com/pcantrell)
+
+
 ## 0.2.2
 
 ##### Breaking

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -181,7 +181,7 @@ module Jazzy
 
         opt.on('-e', '--exclude file1,file2,…fileN', Array,
                'Files to be excluded from documentation') do |files|
-          config.excluded_files = files
+          config.excluded_files = files.map { |f| File.expand_path(f) }
         end
 
         opt.on('-v', '--version', 'Print version number') do


### PR DESCRIPTION
The `--exclude` option currently only works with absolute paths, and fails silently with relative paths.