### PR TITLE
Fixed broken extension? test

### DIFF
--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -48,7 +48,7 @@ module Jazzy
       end
 
       def extension?
-        kind =~ /^source\.lang\.swift\.extension.*/
+        kind =~ /^source\.lang\.swift\.decl\.extension.*/
       end
 
       def param?


### PR DESCRIPTION
Though it’s not clear what effect it has, the `extension?` test currently always returns false.