### PR TITLE
Don’t document empty extensions

### DIFF
--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -104,7 +104,12 @@ module Jazzy
 
       # Document extensions & enum elements, since we can't tell their ACL.
       type = SourceDeclaration::Type.new(doc['key.kind'])
-      return true if type.extension? || type.enum_element?
+      return true if type.enum_element?
+      if type.extension?
+        return (doc['key.substructure'] || []).any? do |subdoc|
+          should_document?(subdoc)
+        end
+      end
 
       SourceDeclaration::AccessControlLevel.from_doc(doc) >= @min_acl
     end


### PR DESCRIPTION
Jazzy currently generates an empty doc for an extension with no visible members. Unlikes structs and classes, a memberless extension conveys no useful information.

This is a particularly bad problem because Jazzy can’t distinguish internal extensions from public ones, and thus documents _all_ extensions. The internal ones have no members, and so show up as a bunch of empty (and confusing!) pages.

Won’t work unless #275 is also merged.