### PR TITLE
Merge extensions into the type they extend when it is in the same project

### DIFF
--- a/lib/jazzy/assets/css/jazzy.css.scss
+++ b/lib/jazzy/assets/css/jazzy.css.scss
@@ -313,6 +313,11 @@ header {
     padding-left: 3px;
     margin-left: 15px;
   }
+  .has_default_implementation {
+    font-size: .85em;
+    color: rgba(128,128,128,1);
+    font-style: italic;
+  }
 }
 
 .pointer-container {

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -229,6 +229,7 @@ module Jazzy
       }
       gh_token_url = gh_token_url(item, source_module)
       item_render[:github_token_url] = gh_token_url
+      item_render[:default_impl_abstract] = Jazzy.markdown.render(item.default_impl_abstract) if item.default_impl_abstract
       item_render[:return] = Jazzy.markdown.render(item.return) if item.return
       item_render[:parameters] = item.parameters if item.parameters.any?
       item_render[:url] = item.url if item.children.any?

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -14,6 +14,7 @@ module Jazzy
     attr_accessor :name
     attr_accessor :declaration
     attr_accessor :abstract
+    attr_accessor :default_impl_abstract
     attr_accessor :discussion
     attr_accessor :return
     attr_accessor :children

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -51,6 +51,10 @@ module Jazzy
         kind =~ /^source\.lang\.swift\.decl\.extension.*/
       end
 
+      def extensible?
+        kind =~ /^source\.lang\.swift\.decl\.(class|struct|protocol|enum)$/
+      end
+
       def param?
         # SourceKit strangely categorizes initializer parameters as local
         # variables, so both kinds represent a parameter in jazzy.

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -55,6 +55,10 @@ module Jazzy
         kind =~ /^source\.lang\.swift\.decl\.(class|struct|protocol|enum)$/
       end
 
+      def protocol?
+        kind =~ /^source\.lang\.swift\.decl\.protocol$/
+      end
+
       def param?
         # SourceKit strangely categorizes initializer parameters as local
         # variables, so both kinds represent a parameter in jazzy.

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -250,13 +250,28 @@ module Jazzy
 
     # Merges all of the given types and extensions into a single document.
     def self.merge_declarations(decls)
-      extensions, types = decls.partition { |d| d.type.extension? }
+      extensions, typedecls = decls.partition { |d| d.type.extension? }
 
-      types.select { |t| t.type.protocol? }.each do |protocol|
-        merge_default_implementations_into_protocol(protocol, extensions)
+      if typedecls.size > 1
+        warn "Found conflicting type declarations with the same name, which " +
+          "may indicate a build issue or a bug in Jazzy: " +
+          types.map { |t| "#{t.type.name.downcase} #{t.name}" }.join(', ')
+      end
+      typedecl = typedecls.first
+
+      if typedecl && typedecl.type.protocol?
+        merge_default_implementations_into_protocol(typedecl, extensions)
+        extensions.reject! { |ext| ext.children.empty? }
+
+        ext_mark = SourceMark.new('- Extension Members')
+        extensions.each do |ext|
+          ext.children.each do |ext_member|
+            ext_member.mark = ext_mark
+          end
+        end
       end
 
-      decls = types + extensions
+      decls = typedecls + extensions
       decls.first.tap do |d|
         d.children = deduplicate_declarations(decls.flat_map(&:children).uniq)
       end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -231,14 +231,11 @@ module Jazzy
     #
     # Merges redundant declarations when documenting podspecs.
     def self.deduplicate_declarations(declarations)
-      duplicates = declarations.group_by { |d| deduplication_key(d) }.values
+      duplicate_groups = declarations.group_by { |d| deduplication_key(d) }.values
 
-      duplicates.map do |decls|
+      duplicate_groups.map do |group|
         # Put extended type (if present) before extensions
-        decls = decls.partition { |d| d.type.extensible? }.flatten
-        decls.first.tap do |d|
-          d.children = deduplicate_declarations(decls.flat_map(&:children).uniq)
-        end
+        merge_declarations(group)
       end
     end
 
@@ -248,6 +245,37 @@ module Jazzy
         [decl.usr]
       else
         [decl.usr, decl.type.kind]
+      end
+    end
+
+    # Merges all of the given types and extensions into a single document.
+    def self.merge_declarations(decls)
+      extensions, types = decls.partition { |d| d.type.extension? }
+
+      types.select { |t| t.type.protocol? }.each do |protocol|
+        merge_default_implementations_into_protocol(protocol, extensions)
+      end
+
+      decls = types + extensions
+      decls.first.tap do |d|
+        d.children = deduplicate_declarations(decls.flat_map(&:children).uniq)
+      end
+    end
+
+    # If any of the extensions provide default implementations for methods in the
+    # given protocol, merge those members into the protocol doc instead of keeping
+    # them on the extension.
+    def self.merge_default_implementations_into_protocol(protocol, extensions)
+      protocol.children.each do |proto_method|
+        extensions.each do |ext|
+          defaults, ext.children = ext.children.partition do |ext_member|
+            ext_member.name == proto_method.name
+          end
+          unless defaults.empty?
+            proto_method.default_impl_abstract =
+              defaults.flat_map { |d| [d.abstract, d.discussion] }.join("\n\n")
+          end
+        end
       end
     end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -255,7 +255,7 @@ module Jazzy
       if typedecls.size > 1
         warn "Found conflicting type declarations with the same name, which " +
           "may indicate a build issue or a bug in Jazzy: " +
-          types.map { |t| "#{t.type.name.downcase} #{t.name}" }.join(', ')
+          typedecls.map { |t| "#{t.type.name.downcase} #{t.name}" }.join(', ')
       end
       typedecl = typedecls.first
 

--- a/lib/jazzy/templates/task.mustache
+++ b/lib/jazzy/templates/task.mustache
@@ -17,6 +17,11 @@
         <a name="//apple_ref/swift/{{dash_type}}/{{name}}" class="dashAnchor"></a>
         <a class="token" href="#/{{usr}}">{{name}}</a>
         </code>
+        {{#default_impl_abstract}}
+          <span class="has_default_implementation">
+            Default implementation
+          </span>
+        {{/default_impl_abstract}}
       </div>
       <div class="height-container">
         <div class="pointer-container"></div>
@@ -30,6 +35,12 @@
             {{/url}}
           </div>
           {{/abstract}}
+          {{#default_impl_abstract}}
+          <h4>Default Implementation</h4>
+          <div class="default_impl abstract">
+            {{{default_impl_abstract}}}
+          </div>
+          {{/default_impl_abstract}}
           {{#declaration}}
           <div class="declaration">
             <h4>Declaration</h4>


### PR DESCRIPTION
It’s common for a framework to break up a large declaration into several smaller extensions. When a framework does this with a type it declares, I consider it an implementation detail.

However, while Jazzy merges all the extensions, it keeps them separate from the core type they extend. This makes it hard to find all the methods of that type. (Take a look at how messy the Alamofire docs for `Request` come out, for example.)

This PR groups extensions with the type they extend _if_ it is declared in the same project, instead of placing them separately under “Extensions.”

I imagine this might be a controversial feature, and may also have implications I don’t understand. I’d be open to adding to this PR:

* a command-line flag to control this behavior,
* documentation, and/or
* a modification to the algorithm.

Let me know what you think.