### PR TITLE
[WIP] Custom categories

### DIFF
--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -192,7 +192,7 @@ module Jazzy
           config.excluded_files = files.map { |f| File.expand_path(f) }
         end
 
-        opt.on('--categories file.json', 'JSON file with custom top-level groupings') do |file|
+        opt.on('--categories file', 'JSON or YAML file with custom top-level groupings.', 'Format is array of groups, each with "name" and "children" attributes.') do |file|
           config.custom_categories = case File.extname(file)
             when '.json'        then JSON.parse(File.read(file))
             when '.yaml','.yml' then YAML.load(File.read(file))

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -30,6 +30,7 @@ module Jazzy
     attr_accessor :docset_path
     attr_accessor :source_directory
     attr_accessor :excluded_files
+    attr_accessor :custom_categories
     attr_accessor :template_directory
     attr_accessor :swift_version
 
@@ -47,6 +48,7 @@ module Jazzy
       self.skip_undocumented = false
       self.source_directory = Pathname.pwd
       self.excluded_files = []
+      self.custom_categories = {}
       self.template_directory = Pathname(__FILE__).parent + 'templates'
       self.swift_version = '1.2'
     end
@@ -188,6 +190,14 @@ module Jazzy
         opt.on('-e', '--exclude file1,file2,…fileN', Array,
                'Files to be excluded from documentation') do |files|
           config.excluded_files = files.map { |f| File.expand_path(f) }
+        end
+
+        opt.on('--categories file.json', 'JSON file with custom top-level groupings') do |file|
+          config.custom_categories = case File.extname(file)
+            when '.json'        then JSON.parse(File.read(file))
+            when '.yaml','.yml' then YAML.load(File.read(file))
+            else raise "File provided for --categories must be .yaml or .json"
+          end
         end
 
         opt.on('-v', '--version', 'Print version number') do

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -192,12 +192,9 @@ module Jazzy
           config.excluded_files = files.map { |f| File.expand_path(f) }
         end
 
-        opt.on('--categories file', 'JSON or YAML file with custom top-level groupings.', 'Format is array of groups, each with "name" and "children" attributes.') do |file|
-          config.custom_categories = case File.extname(file)
-            when '.json'        then JSON.parse(File.read(file))
-            when '.yaml','.yml' then YAML.load(File.read(file))
-            else raise "File provided for --categories must be .yaml or .json"
-          end
+        opt.on('--categories file',
+               'JSON or YAML file with custom groupings') do |file|
+          config.custom_categories = parse_config_file(file)
         end
 
         opt.on('-v', '--version', 'Print version number') do
@@ -212,6 +209,14 @@ module Jazzy
       end.parse!
 
       config
+    end
+
+    def parse_config_file(file)
+      case File.extname(file)
+      when '.json'         then JSON.parse(File.read(file))
+      when '.yaml', '.yml' then YAML.load(File.read(file))
+      else raise "Config file must be .yaml or .json, but got #{file.inspect}"
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -70,25 +70,25 @@ module Jazzy
     # @param [Config] options Build options
     # @param [Array] doc_structure @see #doc_structure_for_docs
     def self.build_docs(output_dir, docs, source_module)
-      each_doc(output_dir, docs) do |doc, path, depth|
+      each_doc(output_dir, docs) do |doc, path|
         prepare_output_dir(path.parent, false)
-        path_to_root = ['../'].cycle(depth).to_a.join('')
+        depth = path.relative_path_from(output_dir).each_filename.count - 1
+        path_to_root = '../' * depth
         path.open('w') do |file|
           file.write(document(source_module, doc, path_to_root))
         end
       end
     end
 
-    def self.each_doc(output_dir, docs, depth = 0, &block)
+    def self.each_doc(output_dir, docs, &block)
       docs.each do |doc|
         next if doc.name != 'index' && doc.children.count == 0
-        path = output_dir + "#{doc.name}.html"
-        block.call(doc, path, depth)
+        path = output_dir + (doc.url || "#{doc.name}.html")   # Assumes URL is relative to documentation root!
+        block.call(doc, path)
         next if doc.name == 'index'
         each_doc(
-          output_dir + doc.name,
+          output_dir,
           doc.children,
-          depth + 1,
           &block
         )
       end

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -31,7 +31,7 @@ module Jazzy
       docs.map do |doc|
         {
           section: doc.name,
-          children: doc.children.sort_by(&:name).map do |child|
+          children: doc.children.sort_by(&:name).sort_by(&:nav_order).map do |child|
             { name: child.name, url: child.url }
           end,
         }

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -31,9 +31,12 @@ module Jazzy
       docs.map do |doc|
         {
           section: doc.name,
-          children: doc.children.sort_by(&:name).sort_by(&:nav_order).map do |child|
-            { name: child.name, url: child.url }
-          end,
+          children: doc.children
+              .sort_by(&:name)
+              .sort_by(&:nav_order)
+              .map do |child|
+                { name: child.name, url: child.url }
+              end,
         }
       end
     end
@@ -83,7 +86,8 @@ module Jazzy
     def self.each_doc(output_dir, docs, &block)
       docs.each do |doc|
         next if doc.name != 'index' && doc.children.count == 0
-        path = output_dir + (doc.url || "#{doc.name}.html")   # Assumes URL is relative to documentation root!
+        # Assuming URL is relative to documentation root:
+        path = output_dir + (doc.url || "#{doc.name}.html")
         block.call(doc, path)
         next if doc.name == 'index'
         each_doc(

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -23,6 +23,7 @@ module Jazzy
     attr_accessor :access_control_level
     attr_accessor :start_line
     attr_accessor :end_line
+    attr_accessor :nav_order
 
     def overview
       "#{abstract}\n\n#{discussion}".strip

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -97,13 +97,11 @@ module Jazzy
 
     # Determine the subdirectory in which a doc should be placed
     def self.subdir_for_doc(doc, parents)
-      # To group docs by category file instead of declaration type,
-      # return parents.map(&:name)
-
-      if doc.type.name
-        [doc.type.plural_name]
-      else
-        []
+      parents.map(&:name).tap do |names|
+        # We always want to create top-level subdirs according to type (Struct,
+        # Class, etc), but parents[0] might be a custom category name.
+        top_level_decl = (parents + [doc])[1]
+        names[0] = top_level_decl.type.plural_name if top_level_decl
       end
     end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -19,7 +19,7 @@ module Jazzy
     def self.group_docs(docs)
       custom_categories, docs = group_custom_categories(docs)
       type_categories, uncategorized = group_type_categories(
-        docs, custom_categories.any? ? "Other " : "")
+        docs, custom_categories.any? ? 'Other' : '')
       custom_categories + type_categories + uncategorized
     end
 
@@ -28,14 +28,14 @@ module Jazzy
         children = category['children'].flat_map do |name|
           docs_with_name, docs = docs.partition { |doc| doc.name == name }
           if docs_with_name.empty?
-            STDERR.puts "WARNING: No documented top-level declarations match "\
+            STDERR.puts 'WARNING: No documented top-level declarations match ' \
                         "name \"#{name}\" specified in categories file"
           end
           docs_with_name
         end
         # Category config overrides alphabetization
         children.each.with_index { |child, i| child.nav_order = i }
-        make_group(children, category["name"], "")
+        make_group(children, category['name'], '')
       end
       [group.compact, docs]
     end
@@ -45,7 +45,7 @@ module Jazzy
         children, docs = docs.partition { |doc| doc.type == type }
         make_group(
           children,
-          type_category_prefix + type.plural_name, 
+          type_category_prefix + type.plural_name,
           "The following #{type.plural_name.downcase} are available globally.")
       end
       [group.compact, docs]
@@ -67,17 +67,20 @@ module Jazzy
       docs.each do |doc|
         if parents.empty? || doc.children.count > 0
           # Create HTML page for this doc if it has children or is root-level
-          doc.url = (subdir_for_doc(doc, parents) + [doc.name + '.html']).join('/')
+          doc.url = (
+              subdir_for_doc(doc, parents) +
+              [doc.name + '.html']
+            ).join('/')
           doc.children = make_doc_urls(doc.children, parents + [doc])
         else
           # Don't create HTML page for this doc if it doesn't have children
           # Instead, make its link a hash-link on its parent's page
           if doc.typename == '<<error type>>'
             warn 'A compile error prevented ' +
-              (parents[1..-1] + [doc]).map(&:name).join('.') + ' from receiving a ' \
-              'unique USR. Documentation may be incomplete. Please check for ' \
-              'compile errors by running `xcodebuild ' \
-              "#{Config.instance.xcodebuild_arguments.shelljoin}`."
+              (parents[1..-1] + [doc]).map(&:name).join('.') +
+              ' from receiving a unique USR. Documentation may be ' \
+              'incomplete. Please check for compile errors by running ' \
+              "`xcodebuild #{Config.instance.xcodebuild_arguments.shelljoin}`."
           end
           id = doc.usr
           unless id

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -74,7 +74,7 @@ module Jazzy
           # Instead, make its link a hash-link on its parent's page
           if doc.typename == '<<error type>>'
             warn 'A compile error prevented ' +
-              (parents[1..-1] + [doc.name]).join('.') + ' from receiving a ' \
+              (parents[1..-1] + [doc]).map(&:name).join('.') + ' from receiving a ' \
               'unique USR. Documentation may be incomplete. Please check for ' \
               'compile errors by running `xcodebuild ' \
               "#{Config.instance.xcodebuild_arguments.shelljoin}`."

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -65,11 +65,10 @@ module Jazzy
     # @return [Hash] input docs with URLs
     def self.make_doc_urls(docs, parents)
       docs.each do |doc|
-        if doc.children.count > 0
-          # Create HTML page for this doc if it has children
-          parents_slash = parents.count > 0 ? '/' : ''
-          doc.url = parents.join('/') + parents_slash + doc.name + '.html'
-          doc.children = make_doc_urls(doc.children, parents + [doc.name])
+        if parents.empty? || doc.children.count > 0
+          # Create HTML page for this doc if it has children or is root-level
+          doc.url = (subdir_for_doc(doc, parents) + [doc.name + '.html']).join('/')
+          doc.children = make_doc_urls(doc.children, parents + [doc])
         else
           # Don't create HTML page for this doc if it doesn't have children
           # Instead, make its link a hash-link on its parent's page
@@ -90,11 +89,23 @@ module Jazzy
               'project. If this token is declared in an `#if` block, please ' \
               'ignore this message.'
           end
-          doc.url = parents.join('/') + '.html#/' + id
+          doc.url = parents.last.url + '#/' + id
         end
       end
     end
     # rubocop:enable Metrics/MethodLength
+
+    # Determine the subdirectory in which a doc should be placed
+    def self.subdir_for_doc(doc, parents)
+      # To group docs by category file instead of declaration type,
+      # return parents.map(&:name)
+
+      if doc.type.name
+        [doc.type.plural_name]
+      else
+        []
+      end
+    end
 
     # Run sourcekitten with given arguments and return STDOUT
     def self.run_sourcekitten(arguments)


### PR DESCRIPTION
Allows customized logical grouping and ordering of the lefthand doc nav bar.

Type-based groups can make documentation hard to browse. A struct, for example, may have a closely associated protocol (and have nothing to do with another struct that happens to be next to it in alphabetical order).

A new `--categories` option accepts a YAML or JSON file containing custom categories for the top-level types:

    - name: Core
      children:
      - Service
      - Resource
      - ResourceData
      - ResourceError
      - ResourceObserver
      - ResourceEvent
      - Request
      - RequestMethod
      - Configuration

    - name: Response Parsing
      children:
      - Response
      - ResponseTransformer
      - ResponseDataTransformer
      - TextTransformer
      - JsonTransformer
      - TransformerSequence

    ..etc...

Here is **[what the results look like](http://bustoutsolutions.github.io/siesta/api/)**.

Ordering within each category is preserved. Any types not explicitly categorized show up under “Other Classes,” “Other Protocols,” etc.

On disk, files are still grouped by type (e.g. `Classes/Thinger.html`), not custom categories. The rationale for this is that changing the categories should not break existing links to docs for individual program elements.

If the `--categories` option is not present, Jazzy behaves the same as before.

This needs documentation, and probably testing as well, but I’ll wait for feedback from the core team before undertaking that.