### PR TITLE
Swift 2.0 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   [JP Simard](https://github.com/jpsim)
   [#236](https://github.com/realm/jazzy/issues/236)
 
-* `--exclude` now works properly if its argument is a relative path.
+* `--exclude` now works properly if its argument is a relative path.  
   [pcantrell](https://github.com/pcantrell)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   [JP Simard](https://github.com/jpsim)
   [#236](https://github.com/realm/jazzy/issues/236)
 
+* `--exclude` now works properly if its argument is a relative path.
+  [pcantrell](https://github.com/pcantrell)
+
 
 ## 0.2.3
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -187,7 +187,7 @@ module Jazzy
 
         opt.on('-e', '--exclude file1,file2,…fileN', Array,
                'Files to be excluded from documentation') do |files|
-          config.excluded_files = files
+          config.excluded_files = files.map { |f| File.expand_path(f) }
         end
 
         opt.on('-v', '--version', 'Print version number') do

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -3,8 +3,10 @@ require 'jazzy/source_declaration/type'
 
 module Jazzy
   class SourceDeclaration
-    attr_accessor :type      # kind of declaration (e.g. class, variable, function)
-    attr_accessor :typename  # static type of declared element (e.g. String.Type -> ())
+    # kind of declaration (e.g. class, variable, function)
+    attr_accessor :type
+    # static type of declared element (e.g. String.Type -> ())
+    attr_accessor :typename
     attr_accessor :file
     attr_accessor :line
     attr_accessor :column

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -3,7 +3,8 @@ require 'jazzy/source_declaration/type'
 
 module Jazzy
   class SourceDeclaration
-    attr_accessor :type
+    attr_accessor :type      # kind of declaration (e.g. class, variable, function)
+    attr_accessor :typename  # static type of declared element (e.g. String.Type -> ())
     attr_accessor :file
     attr_accessor :line
     attr_accessor :column

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -41,9 +41,11 @@ module Jazzy
           # Instead, make its link a hash-link on its parent's page
           id = doc.usr
           if id =~ /ERR$/
-            warn "A compile error prevented " + (parents[1..-1] + [doc.name]).join('.') +
+            warn "A compile error prevented " +
+              (parents[1..-1] + [doc]).map(&:name).join('.') +
               " from receiving a unique USR. Documentation may be incomplete. " \
-              "Please check for compile errors by running `xcodebuild`."
+              "Please check for compile errors by running `xcodebuild` along with "\
+              "any arguments passed to jazzy's `-x` or `--xcodebuild-arguments`."
           end
           unless id
             id = doc.name || 'unknown'

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -39,14 +39,14 @@ module Jazzy
         else
           # Don't create HTML page for this doc if it doesn't have children
           # Instead, make its link a hash-link on its parent's page
-          id = doc.usr
-          if id =~ /ERR$/
+          if doc.typename == "<<error type>>"
             warn "A compile error prevented " +
               (parents[1..-1] + [doc]).map(&:name).join('.') +
               " from receiving a unique USR. Documentation may be incomplete. " \
               "Please check for compile errors by running `xcodebuild` along with "\
               "any arguments passed to jazzy's `-x` or `--xcodebuild-arguments`."
           end
+          id = doc.usr
           unless id
             id = doc.name || 'unknown'
             warn "`#{id}` has no USR. First make sure all modules used in " \
@@ -191,6 +191,7 @@ module Jazzy
         end
         declaration = SourceDeclaration.new
         declaration.type = SourceDeclaration::Type.new(doc['key.kind'])
+        declaration.typename = doc['key.typename']
         if declaration.type.mark? && doc['key.name'].start_with?('MARK: ')
           current_mark = SourceMark.new(doc['key.name'])
         end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -100,8 +100,8 @@ module Jazzy
       doc[key].map do |p|
         if para = p['Para']
           Jazzy.markdown.render(para)
-        elsif verbatim = p['Verbatim']
-          Jazzy.markdown.render("```\n#{verbatim}```\n")
+        elsif code = p['Verbatim'] || p['CodeListing']
+          Jazzy.markdown.render("```\n#{code}```\n")
         else
           warn "Jazzy could not recognize the `#{p.keys.first}` tag. " \
                'Please report this by filing an issue at ' \

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -39,7 +39,22 @@ module Jazzy
         else
           # Don't create HTML page for this doc if it doesn't have children
           # Instead, make its link a hash-link on its parent's page
-          doc.url = parents.join('/') + '.html#/' + doc.usr
+          id = doc.usr
+          if id =~ /ERR$/
+            warn "A compile error prevented " + (parents[1..-1] + [doc.name]).join('.') +
+              " from receiving a unique USR. Documentation may be incomplete. " \
+              "Please check for compile errors by running `xcodebuild`."
+          end
+          unless id
+            id = doc.name || 'unknown'
+            warn "`#{id}` has no USR. First make sure all modules used in " \
+              'your project have been imported. If all used modules are ' \
+              'imported, please report this problem by filing an issue at ' \
+              'https://github.com/realm/jazzy/issues along with your Xcode ' \
+              'project. If this token is declared in an `#if` block, please ' \
+              'ignore this message.'
+          end
+          doc.url = parents.join('/') + '.html#/' + id
         end
       end
     end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'pathname'
+require 'shellwords'
 require 'xcinvoke'
 
 require 'jazzy/config'
@@ -27,6 +28,7 @@ module Jazzy
       docs
     end
 
+    # rubocop:disable Metrics/MethodLength
     # Generate doc URL by prepending its parents URLs
     # @return [Hash] input docs with URLs
     def self.make_doc_urls(docs, parents)
@@ -39,12 +41,12 @@ module Jazzy
         else
           # Don't create HTML page for this doc if it doesn't have children
           # Instead, make its link a hash-link on its parent's page
-          if doc.typename == "<<error type>>"
-            warn "A compile error prevented " +
-              (parents[1..-1] + [doc]).map(&:name).join('.') +
-              " from receiving a unique USR. Documentation may be incomplete. " \
-              "Please check for compile errors by running `xcodebuild` along with "\
-              "any arguments passed to jazzy's `-x` or `--xcodebuild-arguments`."
+          if doc.typename == '<<error type>>'
+            warn 'A compile error prevented ' +
+              (parents[1..-1] + [doc.name]).join('.') + ' from receiving a ' \
+              'unique USR. Documentation may be incomplete. Please check for ' \
+              'compile errors by running `xcodebuild ' \
+              "#{Config.instance.xcodebuild_arguments.shelljoin}`."
           end
           id = doc.usr
           unless id
@@ -60,6 +62,7 @@ module Jazzy
         end
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     # Run sourcekitten with given arguments and return STDOUT
     def self.run_sourcekitten(arguments)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -116,7 +116,7 @@ describe_cli 'jazzy' do
                             '--root-url https://realm.io/docs/swift/' \
                             "#{realm_version}/api/ " \
                             '--xcodebuild-arguments ' \
-                            '"-project,RealmSwift.xcodeproj,-dry-run" '
+                            '-project,RealmSwift.xcodeproj,-dry-run'
     end
 
     describe 'Creates docs for a podspec with dependencies and subspecs' do


### PR DESCRIPTION
Includes all of @pcantrell's merged Swift 2.0 PRs that were also applicable to Swift 1.2 so we can cut a release with those features for Swift 1.2 before merging Swift 2.0.