### PR TITLE
Show type declarations under heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Improved how SourceKitten is vendored.  
   [JP Simard](https://github.com/jpsim)
 
+* Show type declaration under its title.  
+  [pcantrell](https://github.com/pcantrell)
+
 ##### Bug Fixes
 
 * Fixed a crash when parsing an empty documentation comment.  

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -283,6 +283,7 @@ module Jazzy
       doc[:name] = doc_model.name
       doc[:kind] = doc_model.type.name
       doc[:dash_type] = doc_model.type.dash_type
+      doc[:declaration] = doc_model.declaration
       doc[:overview] = Jazzy.markdown.render(doc_model.overview)
       doc[:structure] = source_module.doc_structure
       doc[:tasks] = render_tasks(source_module, doc_model.children)

--- a/lib/jazzy/templates/doc.mustache
+++ b/lib/jazzy/templates/doc.mustache
@@ -27,6 +27,13 @@
         <section>
           <section class="section">
             {{^hide_name}}<h1>{{name}}</h1>{{/hide_name}}
+            {{#declaration}}
+              <div class="declaration">
+                <div class="Swift">
+                  {{{declaration}}}
+                </div>
+              </div>
+            {{/declaration}}
             {{{overview}}}
           </section>
           {{> tasks}}


### PR DESCRIPTION
This is #280 but targeting `master` and with updated integration specs.