### PR TITLE
Fixed bug where "View on GitHub" was always shown

### DIFF
--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -183,7 +183,7 @@ module Jazzy
       doc[:structure] = source_module.doc_structure
       doc[:module_name] = source_module.name
       doc[:author_name] = source_module.author_name
-      doc[:github_url] = source_module.github_url.to_s
+      doc[:github_url] = source_module.github_url
       doc[:dash_url] = source_module.dash_url
       doc[:path_to_root] = path_to_root
       doc[:hide_name] = true
@@ -287,7 +287,7 @@ module Jazzy
       doc[:tasks] = render_tasks(source_module, doc_model.children)
       doc[:module_name] = source_module.name
       doc[:author_name] = source_module.author_name
-      doc[:github_url] = source_module.github_url.to_s
+      doc[:github_url] = source_module.github_url
       doc[:dash_url] = source_module.dash_url
       doc[:path_to_root] = path_to_root
       doc.render


### PR DESCRIPTION
It seems that the bug was cause by using `to_s` on the `github_url` which caused it to be an empty string and not `null` or `false` so `mustache` would leave it out.

Refs #244 

This change naturally requires that `document_moya_podspec` is updated with a lot of `<p class="header-right"><a href=""><img src="img/gh.png"/>View on GitHub</a></p>` removed.
How do we tackle this?