### PR TITLE
Hide documentation coverage option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   [JP Simard](https://github.com/jpsim)
   [#259](https://github.com/realm/jazzy/issues/259)
 
+* Hide documentation coverage from header using `--hide-documentation-coverage`.  
+  [mbogh](https://github.com/mbogh)
+  [#129](https://github.com/realm/jazzy/issues/297)
+
 
 ## 0.3.1
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -25,6 +25,7 @@ module Jazzy
     attr_accessor :version
     attr_accessor :min_acl
     attr_accessor :skip_undocumented
+    attr_accessor :hide_documentation_coverage
     attr_accessor :podspec
     attr_accessor :docset_icon
     attr_accessor :docset_path
@@ -48,6 +49,7 @@ module Jazzy
       self.version = '1.0'
       self.min_acl = SourceDeclaration::AccessControlLevel.public
       self.skip_undocumented = false
+      self.hide_documentation_coverage = false
       self.source_directory = Pathname.pwd
       self.excluded_files = []
       self.custom_categories = {}
@@ -156,6 +158,12 @@ module Jazzy
                comments.",
                ) do |skip_undocumented|
           config.skip_undocumented = skip_undocumented
+        end
+
+        opt.on('--[no-]hide-documentation-coverage',
+               "Hide \"(X\% documented)\" from the generated documents",
+               ) do |hide_documentation_coverage|
+          config.hide_documentation_coverage = hide_documentation_coverage
         end
 
         opt.on('--podspec FILEPATH') do |podspec|

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -183,7 +183,8 @@ module Jazzy
       doc = Doc.new # Mustache model instance
       doc[:name] = source_module.name
       doc[:overview] = ReadmeGenerator.generate(source_module)
-      doc[:doc_coverage] = source_module.doc_coverage unless Config.instance.hide_documentation_coverage
+      doc[:doc_coverage] = source_module.doc_coverage unless
+        Config.instance.hide_documentation_coverage
       doc[:structure] = source_module.doc_structure
       doc[:module_name] = source_module.name
       doc[:author_name] = source_module.author_name
@@ -283,7 +284,8 @@ module Jazzy
       end
 
       doc = Doc.new # Mustache model instance
-      doc[:doc_coverage] = source_module.doc_coverage unless Config.instance.hide_documentation_coverage
+      doc[:doc_coverage] = source_module.doc_coverage unless
+        Config.instance.hide_documentation_coverage
       doc[:name] = doc_model.name
       doc[:kind] = doc_model.type.name
       doc[:dash_type] = doc_model.type.dash_type

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -183,7 +183,7 @@ module Jazzy
       doc = Doc.new # Mustache model instance
       doc[:name] = source_module.name
       doc[:overview] = ReadmeGenerator.generate(source_module)
-      doc[:doc_coverage] = source_module.doc_coverage
+      doc[:doc_coverage] = source_module.doc_coverage unless Config.instance.hide_documentation_coverage
       doc[:structure] = source_module.doc_structure
       doc[:module_name] = source_module.name
       doc[:author_name] = source_module.author_name
@@ -283,7 +283,7 @@ module Jazzy
       end
 
       doc = Doc.new # Mustache model instance
-      doc[:doc_coverage] = source_module.doc_coverage
+      doc[:doc_coverage] = source_module.doc_coverage unless Config.instance.hide_documentation_coverage
       doc[:name] = doc_model.name
       doc[:kind] = doc_model.type.name
       doc[:dash_type] = doc_model.type.dash_type

--- a/lib/jazzy/templates/header.mustache
+++ b/lib/jazzy/templates/header.mustache
@@ -1,6 +1,6 @@
 <header>
   <div class="content-wrapper">
-    <p><a href="{{path_to_root}}index.html">{{module_name}} Docs</a> ({{doc_coverage}}% documented)</p>
+    <p><a href="{{path_to_root}}index.html">{{module_name}} Docs</a>{{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}</p>
     {{#github_url}}
     <p class="header-right"><a href="{{github_url}}"><img src="{{path_to_root}}img/gh.png"/>View on GitHub</a></p>
     {{/github_url}}

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -177,7 +177,8 @@ describe_cli 'jazzy' do
                             '-u https://github.com/realm/jazzy ' \
                             '-g https://github.com/realm/jazzy ' \
                             '-x -dry-run ' \
-                            '--min-acl private'
+                            '--min-acl private ' \
+                            '--hide-documentation-coverage'
     end
   end if !travis_swift || travis_swift == '2.0'
 end


### PR DESCRIPTION
Added the cli option `--[no-]hide-documentation-coverage`, so it is easy to hide documentation coverage in e.g. "release" versions of the documentation. Resolves #297 

```
jazzy -h
...
--[no-]hide-documentation-coverage
                                     Hide "(X% documented)" from the generated documents
...
```

I have added `--hide-documentation-coverage` to `misc_jazzy_features`.

[jazzy-integration-specs PR](https://github.com/realm/jazzy-integration-specs/pull/5)