### PR TITLE
Always add objective-c args when objective-c mode is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,11 @@
   [Jeff Verkoeyen](https://github.com/jverkoey)
   [#347](https://github.com/realm/jazzy/issues/347)
 
+##### Bug Fixes
+
 * --objc arguments are now joined with provided -x arguments.
   [Jeff Verkoeyen](https://github.com/jverkoey)
   [#351](https://github.com/realm/jazzy/issues/351)
-
-##### Bug Fixes
-
-* None.
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   [Jeff Verkoeyen](https://github.com/jverkoey)
   [#347](https://github.com/realm/jazzy/issues/347)
 
+* --objc arguments are now joined with provided -x arguments.
+  [Jeff Verkoeyen](https://github.com/jverkoey)
+  [#351](https://github.com/realm/jazzy/issues/351)
+
 ##### Bug Fixes
 
 * None.

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -114,12 +114,9 @@ module Jazzy
     def self.arguments_from_options(options)
       arguments = ['doc']
       if options.objc_mode
-        if options.xcodebuild_arguments.empty?
-          arguments += ['--objc', options.umbrella_header.to_s, '-x',
-                        'objective-c', '-isysroot',
-                        `xcrun --show-sdk-path`.chomp, '-I',
-                        options.framework_root.to_s]
-        end
+        arguments += ['--objc', options.umbrella_header.to_s, '-x',
+                      'objective-c', '-I',
+                      options.framework_root.to_s]
       elsif !options.module_name.empty?
         arguments += ['--module-name', options.module_name]
       end


### PR DESCRIPTION
Makes it possible to specify custom -x values without losing the Objective-C-related flags. Notably this allows sysroot to be configured from the command line without having to specify all of the ObjC flags.