### PR TITLE
Autolink improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
   [Jeff Verkoeyen](https://github.com/jverkoey)
   [#347](https://github.com/realm/jazzy/issues/347)
 
+* Autolinking improvements:
+  - Autolinks only match `` `ThingsInBackticks` ``, and must match the entire
+    string. This prevents spurious matching in prose and sample code.
+  - Autolinks supports siblings, ancestors, top-level elements, and
+    dot-separated chains starting with any of the above: `someProperty`,
+    `SomeType.NestedType.someMethod(_:)`.
+  - New `...` wildcard prevents you from having to list all method parameters:
+    `someMethod(...)`
+
+  [pcantrell](https://github.com/pcantrell)
+
 ##### Bug Fixes
 
 * None.

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -7,6 +7,39 @@ module Jazzy
     attr_accessor :type
     # static type of declared element (e.g. String.Type -> ())
     attr_accessor :typename
+
+    # Element containing this declaration in the code
+    attr_accessor :parent_in_code
+
+    # Logical parent in the documentation. May differ from parent_in_code
+    # because of top-level categories and merged extensions.
+    attr_accessor :parent_in_docs
+
+    # counterpart of parent_in_docs
+    attr_accessor :children
+
+    def children=(new_children)
+      @children = new_children.freeze
+      @children.each { |c| c.parent_in_docs = self }
+    end
+
+    # Chain of parent_in_code from top level to self. (Includes self.)
+    def namespace_path
+      namespace_ancestors + [self]
+    end
+
+    def namespace_ancestors
+      if parent_in_code
+        parent_in_code.namespace_path
+      else
+        []
+      end
+    end
+
+    def fully_qualified_name
+      namespace_path.map(&:name).join('.')
+    end
+
     attr_accessor :file
     attr_accessor :line
     attr_accessor :column
@@ -18,7 +51,6 @@ module Jazzy
     attr_accessor :from_protocol_extension
     attr_accessor :discussion
     attr_accessor :return
-    attr_accessor :children
     attr_accessor :parameters
     attr_accessor :url
     attr_accessor :mark
@@ -30,5 +62,6 @@ module Jazzy
     def overview
       "#{abstract}\n\n#{discussion}".strip
     end
+
   end
 end

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -62,6 +62,5 @@ module Jazzy
     def overview
       "#{abstract}\n\n#{discussion}".strip
     end
-
   end
 end

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -19,6 +19,7 @@ module Jazzy
     attr_accessor :children
 
     def children=(new_children)
+      # Freeze to ensure that parent_in_docs stays in sync
       @children = new_children.freeze
       @children.each { |c| c.parent_in_docs = self }
     end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -465,7 +465,7 @@ module Jazzy
         doc.children.select { |child| child.type.objc_enum? }.map(&:name)
       end
       docs.map do |doc|
-        doc.children.reject! do |child|
+        doc.children = doc.children.reject do |child|
           child.type.objc_typedef? && enums.include?(child.name)
         end
         doc

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -403,8 +403,8 @@ module Jazzy
     def self.name_match(name_part, docs)
       return nil unless name_part
       wildcard_expansion = Regexp.escape(name_part)
-        .gsub('\.\.\.', '[^)]*')
-        .gsub(/&lt;.*&gt;/, '')
+                           .gsub('\.\.\.', '[^)]*')
+                           .gsub(/&lt;.*&gt;/, '')
       whole_name_pat = /\A#{wildcard_expansion}\Z/
       docs.find do |doc|
         whole_name_pat =~ doc.name

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -396,14 +396,14 @@ module Jazzy
     end
 
     def self.autolink_text(text, data, url)
-      regex = /\b(#{data.map { |d| Regexp.escape(d[:name]) }.join('|')})\b/
+      regex = /<code>\s*(#{data.map { |d| Regexp.escape(d[:name]) }.join('|')})\s*<\/code>/
       text.gsub(regex) do
         name = Regexp.last_match(1)
         auto_url = data.find { |d| d[:name] == name }[:url]
         if auto_url == url # docs shouldn't autolink to themselves
           Regexp.last_match(0)
         else
-          "<a href=\"#{ELIDED_AUTOLINK_TOKEN}#{auto_url}\">#{name}</a>"
+          "<code><a href=\"#{ELIDED_AUTOLINK_TOKEN}#{auto_url}\">#{name}</a></code>"
         end
       end
     end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -411,11 +411,12 @@ module Jazzy
 
     # Find the first ancestor of doc whose name matches name_part.
     def self.ancestor_name_match(name_part, doc)
-      doc.namespace_ancestors.reverse_each.first do |ancestor|
+      doc.namespace_ancestors.reverse_each do |ancestor|
         if match = name_match(name_part, ancestor.children)
           return match
         end
       end
+      nil
     end
 
     def self.name_traversal(name_parts, doc)

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -405,7 +405,6 @@ module Jazzy
       wildcard_expansion = Regexp.escape(name_part)
         .gsub('\.\.\.', '[^)]*')
         .gsub(/&lt;.*&gt;/, '')
-p wildcard_expansion
       whole_name_pat = /\A#{wildcard_expansion}\Z/
       docs.find do |doc|
         whole_name_pat =~ doc.name

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -409,11 +409,10 @@ module Jazzy
     end
 
     def self.autolink(docs, data)
-      docs.map do |doc|
+      docs.each do |doc|
         doc.abstract = autolink_text(doc.abstract, data, doc.url)
         doc.return = autolink_text(doc.return, data, doc.url) if doc.return
         doc.children = autolink(doc.children, data)
-        doc
       end
     end
 
@@ -445,8 +444,8 @@ module Jazzy
         # than min_acl
         docs = docs.reject { |doc| doc.type.swift_enum_element? }
       end
-      docs = make_doc_urls(docs, [])
-      docs = autolink(docs, names_and_urls(docs.flat_map(&:children)))
+      make_doc_urls(docs, [])
+      autolink(docs, names_and_urls(docs.flat_map(&:children)))
       [docs, doc_coverage, @undocumented_tokens]
     end
   end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -402,7 +402,10 @@ module Jazzy
 
     def self.name_match(name_part, docs)
       return nil unless name_part
-      wildcard_expansion = Regexp.escape(name_part).gsub('\.\.\.', '[^)]*')
+      wildcard_expansion = Regexp.escape(name_part)
+        .gsub('\.\.\.', '[^)]*')
+        .gsub(/&lt;.*&gt;/, '')
+p wildcard_expansion
       whole_name_pat = /\A#{wildcard_expansion}\Z/
       docs.find do |doc|
         whole_name_pat =~ doc.name

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -352,8 +352,11 @@ module Jazzy
       end
 
       decls = typedecls + extensions
-      decls.first.tap do |d|
-        d.children = deduplicate_declarations(decls.flat_map(&:children).uniq)
+      decls.first.tap do |merged|
+        merged.children = deduplicate_declarations(decls.flat_map(&:children).uniq)
+        merged.children.each do |child|
+          child.parent_in_code = merged
+        end
       end
     end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -443,11 +443,8 @@ module Jazzy
         link_target = name_traversal(parts, name_root)
 
         if link_target && link_target.url && link_target.url != doc.url
-          "<code>
-            <a href=\"#{ELIDED_AUTOLINK_TOKEN}#{link_target.url}\">
-              #{raw_name}
-            </a>
-          </code>"
+          "<code><a href=\"#{ELIDED_AUTOLINK_TOKEN}#{link_target.url}\">" +
+            raw_name + '</a></code>'
         else
           original
         end


### PR DESCRIPTION
This PR allows auto-links to siblings, ancestors, top-level elements, and dot-separated chains starting with any of the above:

<img width="738" alt="screen shot 2015-11-03 at 12 18 19 am" src="https://cloud.githubusercontent.com/assets/378162/10902260/c478306e-81c0-11e5-85bd-425ebc3a9fd0.png">

It allows a `(...)` for long parameter lists, and per the original implementation, does not link from an element to itself:

<img width="737" alt="screen shot 2015-11-03 at 12 18 56 am" src="https://cloud.githubusercontent.com/assets/378162/10902264/d8cf318e-81c0-11e5-8a7d-e1d0dec903d8.png">

It only links single-backticked text — nothing inside code blocks, nothing inside plain text. Here, “Configuration” happens to be the name of a struct in this project, but is used here as a plain English word in a situation where linking to the struct would be downright misleading:

<img width="734" alt="screen shot 2015-11-03 at 12 19 33 am" src="https://cloud.githubusercontent.com/assets/378162/10902291/2ee3b3ce-81c1-11e5-8024-57b0c886b50d.png">

As with previous changes to the generated docs, I’ll gather any feedback on the implementation first, then update integration specs. And changelog!

Fixes #328.