### PR TITLE
Add a Tasks list to the left column.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   [Jeff Verkoeyen](https://github.com/jverkoey)
   [#347](https://github.com/realm/jazzy/issues/347)
 
+* Show the list of Tasks in the sidebar.  
+  [Jeff Verkoeyen](https://github.com/jverkoey)
+  [#357](https://github.com/realm/jazzy/issues/357)
+
 ##### Bug Fixes
 
 * None.

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -297,6 +297,13 @@ module Jazzy
         return document_index(source_module, path_to_root)
       end
 
+      tasks = render_tasks(source_module, doc_model.children)
+      tasks_list_children = tasks.map do |task|
+        if task[:name]
+          { name: task[:name], url: "#/"+task[:uid] }
+        end
+      end
+
       doc = Doc.new # Mustache model instance
       doc[:doc_coverage] = source_module.doc_coverage unless
         Config.instance.hide_documentation_coverage
@@ -306,7 +313,10 @@ module Jazzy
       doc[:declaration] = doc_model.declaration
       doc[:overview] = Jazzy.markdown.render(doc_model.overview)
       doc[:structure] = source_module.doc_structure
-      doc[:tasks] = render_tasks(source_module, doc_model.children)
+      doc[:tasks] = tasks
+      if tasks_list_children.any?
+        doc[:tasks_list] = [{children: tasks_list_children}]
+      end
       doc[:module_name] = source_module.name
       doc[:author_name] = source_module.author_name
       doc[:github_url] = source_module.github_url

--- a/lib/jazzy/templates/nav.mustache
+++ b/lib/jazzy/templates/nav.mustache
@@ -1,5 +1,17 @@
 <nav class="sidebar">
   <ul class="nav-groups">
+    {{#tasks_list}}
+    <li class="nav-group-name">
+      Tasks
+      <ul class="nav-group-tasks">
+        {{#children}}
+        <li class="nav-group-task">
+          <a href="{{url}}">{{name}}</a>
+        </li>
+        {{/children}}
+      </ul>
+    </li>
+    {{/tasks_list}}
     {{#structure}}
     <li class="nav-group-name">
       <a href="{{path_to_root}}{{section}}.html">{{section}}</a>


### PR DESCRIPTION
Similar to Apple's docs, this "Tasks" section shows all of the task section on the current page.

I've put the Tasks list above the other links which makes it a little harder to jump between APIs because the Tasks list might grow/shrink/not exist. What are your thoughts here @jpsim?