### PR TITLE
Revert "Always add objective-c args when objective-c mode is enabled."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,7 @@
 
 ##### Bug Fixes
 
-* --objc arguments are now joined with provided -x arguments.
-  [Jeff Verkoeyen](https://github.com/jverkoey)
-  [#351](https://github.com/realm/jazzy/issues/351)
+* None.
 
 ## 0.4.0
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -114,9 +114,12 @@ module Jazzy
     def self.arguments_from_options(options)
       arguments = ['doc']
       if options.objc_mode
-        arguments += ['--objc', options.umbrella_header.to_s, '-x',
-                      'objective-c', '-I',
-                      options.framework_root.to_s]
+        if options.xcodebuild_arguments.empty?
+          arguments += ['--objc', options.umbrella_header.to_s, '-x',
+                        'objective-c', '-isysroot',
+                        `xcrun --show-sdk-path`.chomp, '-I',
+                        options.framework_root.to_s]
+        end
       elsif !options.module_name.empty?
         arguments += ['--module-name', options.module_name]
       end


### PR DESCRIPTION
Reverts realm/jazzy#351. Fails the integration tests for me locally.