### PR TITLE
Fixes for broken relative path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,14 @@
 
 ##### Bug Fixes
 
-* None.
+- Links to source files on GitHub are no longer broken when `source_directory`
+  does not point to the current working directory.  
+  [pcantrell](https://github.com/pcantrell)
 
+- When `excluded_files` is specified in a config file, it is now resolved
+  relative to the file (like other options) instead of relative to the working
+  directory.  
+  [pcantrell](https://github.com/pcantrell)
 
 ## 0.3.2
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -126,7 +126,8 @@ module Jazzy
       description: 'Files to be excluded from documentation',
       default: [],
       parse: ->(files) do
-        files.map { |f| File.expand_path(f) }
+        PathnameArray.new(
+          Array(files).map { |f| Pathname(f) })
       end
 
     config_attr :swift_version,
@@ -397,6 +398,12 @@ module Jazzy
       attr.description.each { |line| puts "  #{line}" }
       if attr.default && attr.default != ''
         puts "  Default: #{attr.default}"
+      end
+    end
+
+    class PathnameArray < Array
+      def expand_path(base_path)
+        map { |p| p.expand_path(base_path) }
       end
     end
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -31,7 +31,7 @@ module Jazzy
       end
 
       def set(config, val, mark_configured: true)
-        set_raw(config, parse.call(val))
+        set_raw(config, config.instance_exec(val, &parse))
         config.method("#{name}_configured=").call(true) if mark_configured
       end
 
@@ -67,6 +67,12 @@ module Jazzy
       attr_reader :all_config_attrs
     end
 
+    attr_accessor :base_path
+
+    def expand_path(path)
+      Pathname(path).expand_path(base_path) # nil means Pathname.pwd
+    end
+
     # ──────── Build ────────
 
     # rubocop:disable Style/AlignParameters
@@ -75,7 +81,7 @@ module Jazzy
       description: 'Folder to output the HTML docs to',
       command_line: ['-o', '--output FOLDER'],
       default: 'docs',
-      parse: ->(o) { Pathname(o) }
+      parse: ->(o) { expand_path(o) }
 
     config_attr :clean,
       command_line: ['-c', '--[no-]clean'],
@@ -92,18 +98,18 @@ module Jazzy
     config_attr :umbrella_header,
       command_line: '--umbrella-header PATH',
       description: 'Umbrella header for your Objective-C framework.',
-      parse: ->(uh) { Pathname(uh) }
+      parse: ->(uh) { expand_path(uh) }
 
     config_attr :framework_root,
       command_line: '--framework-root PATH',
       description: 'The root path to your Objective-C framework.',
-      parse: ->(fr) { Pathname(fr) }
+      parse: ->(fr) { expand_path(fr) }
 
     config_attr :config_file,
       command_line: '--config PATH',
       description: ['Configuration file (.yaml or .json)',
                     'Default: .jazzy.yaml in source directory or ancestor'],
-      parse: ->(cf) { Pathname(cf) }
+      parse: ->(cf) { expand_path(cf) }
 
     config_attr :xcodebuild_arguments,
       command_line: ['-x', '--xcodebuild-arguments arg1,arg2,…argN', Array],
@@ -113,21 +119,20 @@ module Jazzy
     config_attr :sourcekitten_sourcefile,
       command_line: ['-s', '--sourcekitten-sourcefile FILEPATH'],
       description: 'File generated from sourcekitten output to parse',
-      parse: ->(s) { Pathname(s) }
+      parse: ->(s) { expand_path(s) }
 
     config_attr :source_directory,
       command_line: '--source-directory DIRPATH',
       description: 'The directory that contains the source to be documented',
       default: Pathname.pwd,
-      parse: ->(sd) { Pathname(sd) }
+      parse: ->(sd) { expand_path(sd) }
 
     config_attr :excluded_files,
       command_line: ['-e', '--exclude file1,file2,…fileN', Array],
       description: 'Files to be excluded from documentation',
       default: [],
       parse: ->(files) do
-        PathnameArray.new(
-          Array(files).map { |f| Pathname(f) })
+        Array(files).map { |f| expand_path(f) }
       end
 
     config_attr :swift_version,
@@ -164,7 +169,7 @@ module Jazzy
     config_attr :readme_path,
       command_line: '--readme FILEPATH',
       description: 'The path to a markdown README file',
-      parse: ->(rp) { Pathname(rp) }
+      parse: ->(rp) { expand_path(rp) }
 
     config_attr :podspec,
       command_line: '--podspec FILEPATH',
@@ -175,7 +180,7 @@ module Jazzy
 
     config_attr :docset_icon,
       command_line: '--docset-icon FILEPATH',
-      parse: ->(di) { Pathname(di) }
+      parse: ->(di) { expand_path(di) }
 
     config_attr :docset_path,
       command_line: '--docset-path DIRPATH',
@@ -237,14 +242,14 @@ module Jazzy
       command_line: ['-t', '--template-directory DIRPATH'],
       description: 'The directory that contains the mustache templates to use',
       default: Pathname(__FILE__).parent + 'templates',
-      parse: ->(td) { Pathname(td) }
+      parse: ->(td) { expand_path(td) }
 
     config_attr :assets_directory,
       command_line: '--assets-directory DIRPATH',
       description: 'The directory that contains the assets (CSS, JS, images) '\
                    'used by the templates',
       default: Pathname(__FILE__).parent + 'assets',
-      parse: ->(ad) { Pathname(ad) }
+      parse: ->(ad) { expand_path(ad) }
 
     # rubocop:enable Style/AlignParameters
 
@@ -305,13 +310,13 @@ module Jazzy
           exit
         end
       end.parse!
-
-      expand_paths(Pathname.pwd)
     end
 
     def parse_config_file
       config_path = locate_config_file
       return unless config_path
+
+      self.base_path = config_path.parent
 
       puts "Using config file #{config_path}"
       config_file = read_config_file(config_path)
@@ -322,7 +327,7 @@ module Jazzy
         end
       end
 
-      expand_paths(config_path.parent)
+      self.base_path = nil
     end
 
     def locate_config_file
@@ -341,15 +346,6 @@ module Jazzy
         when '.json'         then JSON.parse(File.read(file))
         when '.yaml', '.yml' then YAML.load(File.read(file))
         else raise "Config file must be .yaml or .json, but got #{file.inspect}"
-      end
-    end
-
-    def expand_paths(base_path)
-      self.class.all_config_attrs.each do |attr|
-        val = attr.get(self)
-        if val.respond_to?(:expand_path)
-          attr.set_raw(self, val.expand_path(base_path))
-        end
       end
     end
 
@@ -398,12 +394,6 @@ module Jazzy
       attr.description.each { |line| puts "  #{line}" }
       if attr.default && attr.default != ''
         puts "  Default: #{attr.default}"
-      end
-    end
-
-    class PathnameArray < Array
-      def expand_path(base_path)
-        map { |p| p.expand_path(base_path) }
       end
     end
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -224,7 +224,8 @@ module Jazzy
       else
         gh_line = "#L#{item.line}"
       end
-      relative_file_path = item.file.realpath.relative_path_from(Pathname.pwd)
+      relative_file_path = item.file.realpath.relative_path_from(
+        source_module.root_path)
       "#{github_prefix}/#{relative_file_path}#{gh_line}"
     end
 

--- a/lib/jazzy/source_module.rb
+++ b/lib/jazzy/source_module.rb
@@ -6,6 +6,7 @@ require 'jazzy/source_declaration'
 module Jazzy
   class SourceModule
     attr_accessor :name
+    attr_accessor :root_path
     attr_accessor :docs
     attr_accessor :doc_coverage
     attr_accessor :doc_structure
@@ -17,6 +18,7 @@ module Jazzy
 
     def initialize(options, docs, doc_structure, doc_coverage)
       self.docs = docs
+      self.root_path = options.source_directory
       self.doc_structure = doc_structure
       self.doc_coverage = doc_coverage
       self.name = options.module_name

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -384,7 +384,7 @@ module Jazzy
       excluded_files = Config.instance.excluded_files
       json.map do |doc|
         key = doc.keys.first
-        doc[key] unless excluded_files.include?(key)
+        doc[key] unless excluded_files.include?(Pathname(key))
       end.compact
     end
 


### PR DESCRIPTION
This fixes two separate but similar bugs in which code incorrectly uses the working directly to resolve a path:

- Github links were generated using the path from the working dir to a specific source file, creating broken links. This fixes it so they use the path from `source_directory` to a specific source file.
- The `excluded_files` option was always resolved relative to the working directory. It is now resolved the same as other path-based options: relative to working dir when specified on the command line, and relative to config file when specified in a config file. I can also see an argument for making this always be relative to `source_directory` no matter where the option is specified. That’s tricky: on the one hand, the exception might be confusing; on the other hand, it seems like `excluded_files` will _always_ be under `source_directory`, so why would you ever want to resolve it relative to anything else?