### PR TITLE
Offset in-page anchors so that they appear below the header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 * Miscellaneous minor font size, weight, and color adjustments.  
   [Jeff Verkoeyen](https://github.com/jverkoey)
 
+* In-page anchors now appear below the header.  
+  [Jeff Verkoeyen](https://github.com/jverkoey)
+  [#356](https://github.com/realm/jazzy/pull/356)
+
 ##### Bug Fixes
 
 * Fix an out-of-bounds exception when generating pragma marks.

--- a/lib/jazzy/assets/css/jazzy.css.scss
+++ b/lib/jazzy/assets/css/jazzy.css.scss
@@ -426,6 +426,13 @@ header {
   font-size: 0.9em;
 }
 
+.anchor {
+  display: block;
+  height: 70px;
+  margin-top: -70px;
+  visibility: hidden;
+}
+
 #footer {
   position: absolute;
   bottom: 10px;

--- a/lib/jazzy/assets/css/jazzy.css.scss
+++ b/lib/jazzy/assets/css/jazzy.css.scss
@@ -298,6 +298,17 @@ header {
   padding-top: 0px;
 }
 
+.task-name-container {
+  a[name] {
+    &:before {
+      content: "";
+      display: block;
+      padding-top: $content_top_offset;
+      margin: -$content_top_offset 0 0;
+    }
+  }
+}
+
 .item {
   padding-top: 8px;
   width: 100%;
@@ -424,13 +435,6 @@ header {
 
 .slightly-smaller {
   font-size: 0.9em;
-}
-
-.anchor {
-  display: block;
-  height: 70px;
-  margin-top: -70px;
-  visibility: hidden;
 }
 
 #footer {

--- a/lib/jazzy/templates/task.mustache
+++ b/lib/jazzy/templates/task.mustache
@@ -1,7 +1,7 @@
 <div class="task-group">
   {{#name}}
   <div class="task-name-container">
-    <a class="anchor" name="/{{uid}}"></a>
+    <a name="/{{uid}}"></a>
     <a name="//apple_ref/{{language_stub}}/Section/{{name}}" class="dashAnchor"></a>
     <a href="#/{{uid}}">
       <h3 class="section-name">{{name}}</h3>

--- a/lib/jazzy/templates/task.mustache
+++ b/lib/jazzy/templates/task.mustache
@@ -1,7 +1,7 @@
 <div class="task-group">
   {{#name}}
   <div class="task-name-container">
-    <a name="/{{uid}}"></a>
+    <a class="anchor" name="/{{uid}}"></a>
     <a name="//apple_ref/{{language_stub}}/Section/{{name}}" class="dashAnchor"></a>
     <a href="#/{{uid}}">
       <h3 class="section-name">{{name}}</h3>


### PR DESCRIPTION
Continued from #356.