### PR TITLE
Stop the document from jumping to the hash when a token is clicked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   [Jeff Verkoeyen](https://github.com/jverkoey)
   [#347](https://github.com/realm/jazzy/issues/347)
 
+* Expanding a token no longer causes the document to 'jump' to the hash.
+  [Jeff Verkoeyen](https://github.com/jverkoey)
+  [#352](https://github.com/realm/jazzy/issues/352)
+
 * Autolinking improvements:
   - Autolinks only match `` `ThingsInBackticks` ``, and must match the entire
     string. This prevents spurious matching in prose and sample code.

--- a/lib/jazzy/assets/js/jazzy.js
+++ b/lib/jazzy/assets/js/jazzy.js
@@ -17,7 +17,7 @@ $(document).ready(function() {
 });
 
 // On token click, toggle its discussion and animate token.marginLeft
-$(".token").click(function() {
+$(".token").click(function(event) {
   if (window.jazzy.docset) {
     return;
   }
@@ -28,4 +28,13 @@ $(".token").click(function() {
   link.animate({'margin-left':original ? "0px" : tokenOffset}, animationDuration);
   $content = link.parent().parent().next();
   $content.slideToggle(animationDuration);
+
+  // Keeps the document from jumping to the hash.
+  var href = $(this).attr('href');
+  if (history.pushState) {
+    history.pushState({}, '', href);
+  } else {
+    location.hash = href;
+  }
+  event.preventDefault();
 });


### PR DESCRIPTION
Continued from #352.