### PR TITLE
Fix whitespace error in :skip_undocumented config.

### DIFF
--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -222,8 +222,8 @@ module Jazzy
 
     config_attr :skip_undocumented,
       command_line: '--[no-]skip-undocumented',
-      description: "Don't document declarations that have no documentation '\
-                  'comments.",
+      description: "Don't document declarations that have no documentation "\
+                  "comments.",
       default: false
 
     config_attr :hide_documentation_coverage,

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -223,7 +223,7 @@ module Jazzy
     config_attr :skip_undocumented,
       command_line: '--[no-]skip-undocumented',
       description: "Don't document declarations that have no documentation "\
-                  "comments.",
+                   'comments.',
       default: false
 
     config_attr :hide_documentation_coverage,


### PR DESCRIPTION
Before: `Don't document declarations that have no documentation '                  'comments.`

After: `Don't document declarations that have no documentation comments.`