### PR TITLE
Add a --lint feature.

### DIFF
--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -220,6 +220,11 @@ module Jazzy
         SourceDeclaration::AccessControlLevel.from_human_string(acl)
       end
 
+    config_attr :lint,
+      command_line: '--[no-]lint',
+      description: "Generate linter output.",
+      default: false
+
     config_attr :skip_undocumented,
       command_line: '--[no-]skip-undocumented',
       description: "Don't document declarations that have no documentation "\
@@ -318,7 +323,7 @@ module Jazzy
 
       self.base_path = config_path.parent
 
-      puts "Using config file #{config_path}"
+      warn "Using config file #{config_path}"
       config_file = read_config_file(config_path)
       self.class.all_config_attrs.each do |attr|
         key = attr.name.to_s

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -222,7 +222,7 @@ module Jazzy
 
     config_attr :lint,
       command_line: '--[no-]lint',
-      description: "Generate linter output.",
+      description: 'Generate linter output.',
       default: false
 
     config_attr :skip_undocumented,

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -107,10 +107,11 @@ module Jazzy
     # @param [String] sourcekitten_output Output of sourcekitten command
     # @param [Config] options Build options
     def self.lint_docs_for_sourcekitten_output(sourcekitten_output, options)
+      skip_undocumented = false
       (docs, coverage, undocumented) = SourceKitten.parse(
         sourcekitten_output,
         options.min_acl,
-        options.skip_undocumented,
+        skip_undocumented,
       )
 
       puts_lint(undocumented)

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -108,7 +108,7 @@ module Jazzy
     # @param [Config] options Build options
     def self.lint_docs_for_sourcekitten_output(sourcekitten_output, options)
       skip_undocumented = false
-      (docs, coverage, undocumented) = SourceKitten.parse(
+      (_, _, undocumented) = SourceKitten.parse(
         sourcekitten_output,
         options.min_acl,
         skip_undocumented,
@@ -185,8 +185,8 @@ module Jazzy
       tokens_by_file.each_key do |file|
         tokens_by_file[file].each do |token|
           puts %w(key.filepath key.doc.line key.name key.kind)
-              .map { |key| token[key].to_s }
-              .join("\t")
+            .map { |key| token[key].to_s }
+            .join("\t")
         end
       end
     end

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -183,7 +183,9 @@ module Jazzy
       end
       tokens_by_file.each_key do |file|
         tokens_by_file[file].each do |token|
-          puts token['key.filepath'] + "\t" + token['key.doc.line'].to_s + "\t" + token['key.kind'] + "\t" + token['key.name']
+          puts %w(key.filepath key.doc.line key.name key.kind)
+              .map { |key| token[key].to_s }
+              .join("\t")
         end
       end
     end

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -65,7 +65,11 @@ module Jazzy
         end
       end
       warn 'building site'
-      build_docs_for_sourcekitten_output(stdout, options)
+      if options.lint
+        lint_docs_for_sourcekitten_output(stdout, options)
+      else
+        build_docs_for_sourcekitten_output(stdout, options)
+      end
     end
 
     # Build & write HTML docs to disk from structured docs array
@@ -97,6 +101,19 @@ module Jazzy
           &block
         )
       end
+    end
+
+    # Lint docs given sourcekitten output
+    # @param [String] sourcekitten_output Output of sourcekitten command
+    # @param [Config] options Build options
+    def self.lint_docs_for_sourcekitten_output(sourcekitten_output, options)
+      (docs, coverage, undocumented) = SourceKitten.parse(
+        sourcekitten_output,
+        options.min_acl,
+        options.skip_undocumented,
+      )
+
+      puts_lint(undocumented)
     end
 
     # Build docs given sourcekitten output
@@ -153,6 +170,21 @@ module Jazzy
         token['key.name']
       else
         'unknown declaration'
+      end
+    end
+
+    def self.puts_lint(undocumented)
+      tokens_by_file = undocumented.group_by do |d|
+        if d['key.filepath']
+          Pathname.new(d['key.filepath']).basename.to_s
+        else
+          d['key.modulename'] || ''
+        end
+      end
+      tokens_by_file.each_key do |file|
+        tokens_by_file[file].each do |token|
+          puts token['key.filepath'] + "\t" + token['key.doc.line'].to_s + "\t" + token['key.kind'] + "\t" + token['key.name']
+        end
       end
     end
 


### PR DESCRIPTION
When enabled, jazzy will write undocumented symbols to stdout and the website will not be generated.

I found the undocumented.txt to be insufficient for building a jazzy-based linter. Consider this pull request a proof of concept :) Would love to start a discussion on what might be the best way to build this.

Undocumented symbols are written one-per-line and tab-delimited in the form:

    path lineno type name

Example output from being run on Nimbus' Attributed Label:

```
.../src/NIAttributedLabel.h	43	sourcekitten.source.lang.objc.decl.enum	NIVerticalTextAlignment
.../src/NIAttributedLabel.h	44	sourcekitten.source.lang.objc.decl.enumcase	NIVerticalTextAlignmentTop
.../src/NIAttributedLabel.h	45	sourcekitten.source.lang.objc.decl.enumcase	NIVerticalTextAlignmentMiddle
.../src/NIAttributedLabel.h	46	sourcekitten.source.lang.objc.decl.enumcase	NIVerticalTextAlignmentBottom
.../src/NIAttributedLabel.h	47	sourcekitten.source.lang.objc.decl.typedef	NIVerticalTextAlignment
.../src/NIAttributedLabel.h	43	sourcekitten.source.lang.objc.decl.enum	NIVerticalTextAlignment
.../src/NIAttributedLabel.h	44	sourcekitten.source.lang.objc.decl.enumcase	NIVerticalTextAlignmentTop
.../src/NIAttributedLabel.h	45	sourcekitten.source.lang.objc.decl.enumcase	NIVerticalTextAlignmentMiddle
.../src/NIAttributedLabel.h	46	sourcekitten.source.lang.objc.decl.enumcase	NIVerticalTextAlignmentBottom
.../src/NIAttributedLabel.h	49	sourcekitten.source.lang.objc.decl.constant	NIAttributedLabelLinkAttributeName
.../src/NIAttributedLabel.h	80	sourcekitten.source.lang.objc.decl.property	attributedString
.../src/NIAttributedLabel.h	82	sourcekitten.source.lang.objc.decl.property	autoDetectLinks
.../src/NIAttributedLabel.h	83	sourcekitten.source.lang.objc.decl.property	dataDetectorTypes
.../src/NIAttributedLabel.h	84	sourcekitten.source.lang.objc.decl.property	deferLinkDetection
.../src/NIAttributedLabel.h	86	sourcekitten.source.lang.objc.decl.method.instance	-addLink:range:
.../src/NIAttributedLabel.h	87	sourcekitten.source.lang.objc.decl.method.instance	-removeAllExplicitLinks
.../src/NIAttributedLabel.h	89	sourcekitten.source.lang.objc.decl.property	linkColor
.../src/NIAttributedLabel.h	90	sourcekitten.source.lang.objc.decl.property	highlightedLinkBackgroundColor
.../src/NIAttributedLabel.h	91	sourcekitten.source.lang.objc.decl.property	linksHaveUnderlines
.../src/NIAttributedLabel.h	92	sourcekitten.source.lang.objc.decl.property	attributesForLinks
.../src/NIAttributedLabel.h	93	sourcekitten.source.lang.objc.decl.property	attributesForHighlightedLink
.../src/NIAttributedLabel.h	94	sourcekitten.source.lang.objc.decl.property	lineHeight
.../src/NIAttributedLabel.h	96	sourcekitten.source.lang.objc.decl.property	verticalTextAlignment
.../src/NIAttributedLabel.h	97	sourcekitten.source.lang.objc.decl.property	underlineStyle
.../src/NIAttributedLabel.h	98	sourcekitten.source.lang.objc.decl.property	underlineStyleModifier
.../src/NIAttributedLabel.h	99	sourcekitten.source.lang.objc.decl.property	shadowBlur
.../src/NIAttributedLabel.h	100	sourcekitten.source.lang.objc.decl.property	strokeWidth
.../src/NIAttributedLabel.h	101	sourcekitten.source.lang.objc.decl.property	strokeColor
.../src/NIAttributedLabel.h	102	sourcekitten.source.lang.objc.decl.property	textKern
.../src/NIAttributedLabel.h	104	sourcekitten.source.lang.objc.decl.property	tailTruncationString
.../src/NIAttributedLabel.h	106	sourcekitten.source.lang.objc.decl.property	shouldSortLinksLast
.../src/NIAttributedLabel.h	108	sourcekitten.source.lang.objc.decl.method.instance	-setFont:range:
.../src/NIAttributedLabel.h	109	sourcekitten.source.lang.objc.decl.method.instance	-setStrokeColor:range:
.../src/NIAttributedLabel.h	110	sourcekitten.source.lang.objc.decl.method.instance	-setStrokeWidth:range:
.../src/NIAttributedLabel.h	111	sourcekitten.source.lang.objc.decl.method.instance	-setTextColor:range:
.../src/NIAttributedLabel.h	112	sourcekitten.source.lang.objc.decl.method.instance	-setTextKern:range:
.../src/NIAttributedLabel.h	113	sourcekitten.source.lang.objc.decl.method.instance	-setUnderlineStyle:modifier:range:
.../src/NIAttributedLabel.h	115	sourcekitten.source.lang.objc.decl.method.instance	-insertImage:atIndex:
.../src/NIAttributedLabel.h	116	sourcekitten.source.lang.objc.decl.method.instance	-insertImage:atIndex:margins:
.../src/NIAttributedLabel.h	117	sourcekitten.source.lang.objc.decl.method.instance	-insertImage:atIndex:margins:verticalTextAlignment:
.../src/NIAttributedLabel.h	119	sourcekitten.source.lang.objc.decl.method.instance	-invalidateAccessibleElements
.../src/NIAttributedLabel.h	121	sourcekitten.source.lang.objc.decl.property	delegate
.../src/NIAttributedLabel.h	80	sourcekitten.source.lang.objc.decl.constant	__NI_DEPRECATED_METHOD
```