### PR TITLE
Add --dry-run flag.

### DIFF
--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -135,6 +135,11 @@ module Jazzy
         Array(files).map { |f| expand_path(f) }
       end
 
+    config_attr :dry_run,
+      command_line: '--dry-run',
+      description: 'No documentation files will be generated during a dry run.',
+      default: false
+
     config_attr :swift_version,
       command_line: '--swift-version VERSION',
       default: '2.1'

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -105,7 +105,9 @@ module Jazzy
     # @return [SourceModule] the documented source module
     def self.build_docs_for_sourcekitten_output(sourcekitten_output, options)
       output_dir = options.output
-      prepare_output_dir(output_dir, options.clean)
+      if !options.dry_run
+        prepare_output_dir(output_dir, options.clean)
+      end
 
       (docs, coverage, undocumented) = SourceKitten.parse(
         sourcekitten_output,
@@ -121,15 +123,19 @@ module Jazzy
       end
 
       source_module = SourceModule.new(options, docs, structure, coverage)
-      build_docs(output_dir, source_module.docs, source_module)
 
-      write_undocumented_file(undocumented, output_dir)
+      if !options.dry_run
+        build_docs(output_dir, source_module.docs, source_module)
 
-      copy_assets(output_dir)
+        write_undocumented_file(undocumented, output_dir)
 
-      DocsetBuilder.new(output_dir, source_module).build!
+        copy_assets(output_dir)
 
-      friendly_path = relative_path_if_inside(output_dir, Pathname.pwd)
+        DocsetBuilder.new(output_dir, source_module).build!
+
+        friendly_path = relative_path_if_inside(output_dir, Pathname.pwd)
+      end
+
       puts "jam out ♪♫ to your fresh new docs in `#{friendly_path}`"
 
       source_module


### PR DESCRIPTION
This flag can be used to verify jazzy config settings without generating any output.

Everything is executed like usual, but nothing is written to disk.

I expect that a safer way to build this config would be to somehow have a disk writer object that could be null'd out when this flag is set.