### PR TITLE
Add --sdk option for Objective-C projects.

### DIFF
--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -107,7 +107,7 @@ module Jazzy
 
     config_attr :sdk,
       command_line: '--sdk [iphone|watch|appletv][os|simulator]|macosx',
-      description: 'The SDK to which your code should be built.',
+      description: 'The SDK for which your code should be built.',
       default: 'macosx'
 
     config_attr :config_file,

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -105,6 +105,11 @@ module Jazzy
       description: 'The root path to your Objective-C framework.',
       parse: ->(fr) { expand_path(fr) }
 
+    config_attr :sdk,
+      command_line: '--sdk [iphone|watch|appletv][os|simulator]|macosx',
+      description: 'The SDK to which your code should be built.',
+      default: 'macosx'
+
     config_attr :config_file,
       command_line: '--config PATH',
       description: ['Configuration file (.yaml or .json)',

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -121,7 +121,7 @@ module Jazzy
         if options.xcodebuild_arguments.empty?
           arguments += ['--objc', options.umbrella_header.to_s, '-x',
                         'objective-c', '-isysroot',
-                        `xcrun --show-sdk-path`.chomp, '-I',
+                        `xcrun --show-sdk-path --sdk #{options.sdk}`.chomp, '-I',
                         options.framework_root.to_s]
         end
       elsif !options.module_name.empty?

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -121,8 +121,8 @@ module Jazzy
         if options.xcodebuild_arguments.empty?
           arguments += ['--objc', options.umbrella_header.to_s, '-x',
                         'objective-c', '-isysroot',
-                        `xcrun --show-sdk-path --sdk #{options.sdk}`.chomp, '-I',
-                        options.framework_root.to_s]
+                        `xcrun --show-sdk-path --sdk #{options.sdk}`.chomp,
+                        '-I', options.framework_root.to_s]
         end
       elsif !options.module_name.empty?
         arguments += ['--module-name', options.module_name]


### PR DESCRIPTION
I presently create `.sh` files that execute jazzy with `xcrun --show-sdk-path --sdk iphonesimulator` so that I can take advantage of `.jazzy.yaml` files. I'm doing this because I can't find a way to run commands from .jazzy.yaml values.

This pull request adds an `--sdk` option which can be used to configure the SDK to which the jazzy docs are built. By default it seems that `macosx` is the default which is problematic for iOS-only SDKs.

This is a follow-up to #358 until jpsim/SourceKitten#88  is resolved.