### PR TITLE
deprecate Swift 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,5 @@ notifications:
   slack: realmio:vPdpsG9NLDo2DNlbqtcMAQuE
 matrix:
   include:
-    - osx_image: xcode6.4
-      env: TRAVIS_SWIFT_VERSION=1.2
     - osx_image: xcode7.2
       env: TRAVIS_SWIFT_VERSION=2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [Nikita Lutsenko](https://github.com/nlutsenko)
   [#416](https://github.com/realm/jazzy/pull/416)
 
+* Swift 1.x is no longer supported.
+
 ##### Enhancements
 
 * Add `--sdk [iphone|watch|appletv][os|simulator]|macosx` option for Objective-C

--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ begin
   task :rebuild_integration_fixtures do
     title 'Running Integration tests'
     sh 'rm -rf spec/integration_specs/tmp'
-    sh 'bundle exec bacon spec/integration_spec.rb'
+    puts `bundle exec bacon spec/integration_spec.rb`
 
     title 'Storing fixtures'
     # Copy the files to the files produced by the specs to the after folders

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -142,7 +142,11 @@ module Jazzy
 
     config_attr :swift_version,
       command_line: '--swift-version VERSION',
-      default: '2.1.1'
+      default: '2.1.1',
+      parse: ->(v) {
+        raise 'jazzy only supports Swift 2.0 or later.' if v.to_f < 2
+        v
+      }
 
     # ──────── Metadata ────────
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -143,10 +143,10 @@ module Jazzy
     config_attr :swift_version,
       command_line: '--swift-version VERSION',
       default: '2.1.1',
-      parse: ->(v) {
+      parse: ->(v) do
         raise 'jazzy only supports Swift 2.0 or later.' if v.to_f < 2
         v
-      }
+      end
 
     # ──────── Metadata ────────
 

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -16,7 +16,7 @@ module Jazzy
       stdout = Dir.chdir(sandbox.root) do
         pod_targets.map do |t|
           SourceKitten.run_sourcekitten(
-            %W(doc --module-name #{podspec.module_name} -target #{t}),
+            %W(doc --module-name #{podspec.module_name} -target #{t})
           )
         end
       end
@@ -114,7 +114,7 @@ module Jazzy
             # platforms for the Moya integration spec, so we just document OSX.
             # TODO: remove once jazzy is fast enough.
             next if ENV['JAZZY_INTEGRATION_SPECS'] &&
-              !p.to_s.start_with?('OS X')
+                    !p.to_s.start_with?('OS X')
             t = "Jazzy-#{ss.name.gsub('/', '__')}-#{p.name}"
             targets << "Pods-#{t}-#{ss.root.name}"
             target(t) do

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -110,6 +110,11 @@ module Jazzy
         platform :ios, '8.0'
         [podspec, *podspec.recursive_subspecs].each do |ss|
           ss.available_platforms.each do |p|
+            # Travis builds take too long when building docs for all available
+            # platforms for the Moya integration spec, so we just document OSX.
+            # TODO: remove once jazzy is fast enough.
+            next if ENV['JAZZY_INTEGRATION_SPECS'] &&
+              !p.to_s.start_with?('OS X')
             t = "Jazzy-#{ss.name.gsub('/', '__')}-#{p.name}"
             targets << "Pods-#{t}-#{ss.root.name}"
             target(t) do

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -16,7 +16,7 @@ module Jazzy
       stdout = Dir.chdir(sandbox.root) do
         pod_targets.map do |t|
           SourceKitten.run_sourcekitten(
-            %W(doc --module-name #{podspec.module_name} -target #{t})
+            %W(doc --module-name #{podspec.module_name} -target #{t}),
           )
         end
       end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -223,24 +223,13 @@ module Jazzy
         doc['key.parsed_declaration'] || doc['key.doc.declaration'],
         Config.instance.objc_mode ? 'objc' : 'swift',
       )
-      declaration.abstract = comment_from_doc(doc)
+      declaration.abstract = Jazzy.markdown.render(doc['key.doc.comment'] || '')
       declaration.discussion = ''
       declaration.return = make_paragraphs(doc, 'key.doc.result_discussion')
 
       declaration.parameters = parameters(doc)
 
       @documented_count += 1
-    end
-
-    def self.comment_from_doc(doc)
-      swift_version = Config.instance.swift_version.to_f
-      comment = doc['key.doc.comment'] || ''
-      if swift_version < 2
-        # comment until first ReST definition
-        matches = /^\s*:[^\s]+:/.match(comment)
-        comment = comment[0...matches.begin(0)] if matches
-      end
-      Jazzy.markdown.render(comment)
     end
 
     def self.make_substructure(doc, declaration)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -81,7 +81,7 @@ describe_cli 'jazzy' do
       'JAZZY_FAKE_DATE'            => 'YYYY-MM-DD',
       'JAZZY_FAKE_VERSION'         => 'X.X.X',
       'COCOAPODS_SKIP_UPDATE_MESSAGE' => 'TRUE',
-      'JAZZY_INTEGRATION_SPECS' => 'TRUE'
+      'JAZZY_INTEGRATION_SPECS' => 'TRUE',
     }
     s.default_args = []
     s.replace_path ROOT.to_s, 'ROOT'

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -81,6 +81,7 @@ describe_cli 'jazzy' do
       'JAZZY_FAKE_DATE'            => 'YYYY-MM-DD',
       'JAZZY_FAKE_VERSION'         => 'X.X.X',
       'COCOAPODS_SKIP_UPDATE_MESSAGE' => 'TRUE',
+      'JAZZY_INTEGRATION_SPECS' => 'TRUE'
     }
     s.default_args = []
     s.replace_path ROOT.to_s, 'ROOT'
@@ -89,65 +90,7 @@ describe_cli 'jazzy' do
 
   travis_swift = ENV['TRAVIS_SWIFT_VERSION']
 
-  describe 'jazzy swift 1.2' do
-    describe 'Creates docs with a module name, author name, project URL, ' \
-      'xcodebuild options, and github info' do
-      behaves_like cli_spec 'document_alamofire1.2',
-                            '-m Alamofire -a Alamofire ' \
-                            '-u https://nshipster.com/alamofire ' \
-                            '-x -project,Alamofire.xcodeproj,-dry-run ' \
-                            '-g https://github.com/Alamofire/Alamofire ' \
-                            '--github-file-prefix https://github.com/' \
-                            'Alamofire/Alamofire/blob/1.3.1 ' \
-                            '--module-version 1.3.1 ' \
-                            '-r http://static.realm.io/jazzy_demo/Alamofire/ ' \
-                            '--skip-undocumented ' \
-                            '--swift-version=1.2'
-    end
-
-    describe 'Creates docs for a podspec with dependencies and subspecs' do
-      behaves_like cli_spec 'document_moya_podspec',
-                            '--podspec=Moya.podspec --swift-version=1.2'
-    end
-  end if !travis_swift || travis_swift == '1.2'
-
-  describe 'jazzy swift 2.1.1' do
-    describe 'Creates docs with a module name, author name, project URL, ' \
-      'xcodebuild options, and github info' do
-      behaves_like cli_spec 'document_alamofire',
-                            '-m Alamofire -a Alamofire ' \
-                            '-u https://nshipster.com/alamofire ' \
-                            '-x -project,Alamofire.xcodeproj,-dry-run ' \
-                            '-g https://github.com/Alamofire/Alamofire ' \
-                            '--github-file-prefix https://github.com/' \
-                            'Alamofire/Alamofire/blob/3.1.1 ' \
-                            '--module-version 3.1.1 ' \
-                            '-r http://static.realm.io/jazzy_demo/Alamofire/ ' \
-                            '--skip-undocumented'
-    end
-
-    describe 'Creates Realm Swift docs' do
-      realm_version = ''
-      Dir.chdir(ROOT + 'spec/integration_specs/document_realm_swift/before') do
-        realm_version = `./build.sh get-version`.chomp
-        `REALM_SWIFT_VERSION=2.1 ./build.sh set-swift-version`
-      end
-      behaves_like cli_spec 'document_realm_swift',
-                            '--author Realm ' \
-                            '--author_url "https://realm.io" ' \
-                            '--github_url ' \
-                            'https://github.com/realm/realm-cocoa ' \
-                            '--github-file-prefix https://github.com/realm/' \
-                            "realm-cocoa/tree/v#{realm_version} " \
-                            '--module RealmSwift ' \
-                            "--module-version #{realm_version} " \
-                            '--root-url https://realm.io/docs/swift/' \
-                            "#{realm_version}/api/ " \
-                            '--xcodebuild-arguments ' \
-                            '-scheme,RealmSwift ' \
-                            '--template-directory docs/templates'
-    end
-
+  describe 'jazzy objective-c' do
     describe 'Creates Realm Objective-C docs' do
       realm_version = ''
       relative_path = 'spec/integration_specs/document_realm_objc/before'
@@ -170,6 +113,48 @@ describe_cli 'jazzy' do
                             "#{realm_version}/api/ " \
                             '--umbrella-header Realm/Realm.h ' \
                             '--framework-root . ' \
+                            '--template-directory docs/templates'
+    end
+  end
+
+  describe 'jazzy swift 2.1.1' do
+    describe 'Creates docs for a podspec with dependencies and subspecs' do
+      behaves_like cli_spec 'document_moya_podspec', '--podspec=Moya.podspec'
+    end
+
+    describe 'Creates docs with a module name, author name, project URL, ' \
+      'xcodebuild options, and github info' do
+      behaves_like cli_spec 'document_alamofire',
+                            '-m Alamofire -a Alamofire ' \
+                            '-u https://nshipster.com/alamofire ' \
+                            '-x -project,Alamofire.xcodeproj,-dry-run ' \
+                            '-g https://github.com/Alamofire/Alamofire ' \
+                            '--github-file-prefix https://github.com/' \
+                            'Alamofire/Alamofire/blob/3.1.1 ' \
+                            '--module-version 3.1.1 ' \
+                            '-r http://static.realm.io/jazzy_demo/Alamofire/ ' \
+                            '--skip-undocumented'
+    end
+
+    describe 'Creates Realm Swift docs' do
+      realm_version = ''
+      Dir.chdir(ROOT + 'spec/integration_specs/document_realm_swift/before') do
+        realm_version = `./build.sh get-version`.chomp
+        `REALM_SWIFT_VERSION=2.1.1 ./build.sh set-swift-version`
+      end
+      behaves_like cli_spec 'document_realm_swift',
+                            '--author Realm ' \
+                            '--author_url "https://realm.io" ' \
+                            '--github_url ' \
+                            'https://github.com/realm/realm-cocoa ' \
+                            '--github-file-prefix https://github.com/realm/' \
+                            "realm-cocoa/tree/v#{realm_version} " \
+                            '--module RealmSwift ' \
+                            "--module-version #{realm_version} " \
+                            '--root-url https://realm.io/docs/swift/' \
+                            "#{realm_version}/api/ " \
+                            '--xcodebuild-arguments ' \
+                            '-scheme,RealmSwift ' \
                             '--template-directory docs/templates'
     end
 


### PR DESCRIPTION
I updated Moya to 4.5.0, which requires CocoaPods 0.39.0, so I bumped that too.

Unfortunately, I think the approach we currently use to generate docs for podspecs (especially with subspecs) isn't viable. See https://github.com/realm/jazzy-integration-specs/blob/jp-deprecate-swift-1/document_moya_podspec/after/docs/undocumented.txt, it looks as though the docs are being generated 20 times! /cc @segiddins 

And the integration specs will fail due to CocoaPods logging the time to warn that the generated Xcode project isn't valid.