### PR TITLE
Use Swift 2.1.1 from Xcode 7.2 by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ matrix:
   include:
     - osx_image: xcode6.4
       env: TRAVIS_SWIFT_VERSION=1.2
-    - osx_image: xcode7.1
-      env: TRAVIS_SWIFT_VERSION=2.1
+    - osx_image: xcode7.2
+      env: TRAVIS_SWIFT_VERSION=2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ##### Breaking
 
-* None.
+* `--swift-version` now defaults to 2.1.1 instead of 2.1.
+  [Nikita Lutsenko](https://github.com/nlutsenko)
+  [#416](https://github.com/realm/jazzy/pull/416)
 
 ##### Enhancements
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -142,7 +142,7 @@ module Jazzy
 
     config_attr :swift_version,
       command_line: '--swift-version VERSION',
-      default: '2.1'
+      default: '2.1.1'
 
     # ──────── Metadata ────────
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -111,7 +111,7 @@ describe_cli 'jazzy' do
     end
   end if !travis_swift || travis_swift == '1.2'
 
-  describe 'jazzy swift 2.1' do
+  describe 'jazzy swift 2.1.1' do
     describe 'Creates docs with a module name, author name, project URL, ' \
       'xcodebuild options, and github info' do
       behaves_like cli_spec 'document_alamofire',
@@ -176,5 +176,5 @@ describe_cli 'jazzy' do
     describe 'Creates docs for Swift project with a variety of contents' do
       behaves_like cli_spec 'misc_jazzy_features', '-x -dry-run'
     end
-  end if !travis_swift || travis_swift == '2.1'
+  end if !travis_swift || travis_swift == '2.1.1'
 end


### PR DESCRIPTION
Xcode 7.2 is using Swift 2.1.1 by default, making jazzy fail completely if trying to generate docs only when the latest Xcode is installed.
Tbh, didn't test the behavior of Jazzy on Swift 2.1.1, but I would assume it didn't quite change.
@jpsim can you try testing this with Realm docs?