### PR TITLE
Integrated markdown

### DIFF
--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -185,6 +185,11 @@ module Jazzy
       description: 'Glob that matches available documentation',
       parse: ->(dg) { glob_path(dg) }
 
+    config_attr :abstract_glob,
+      command_line: '--abstract GLOB',
+      description: 'Glob that matches available abstracts for categories',
+      parse: ->(ag) { glob_path(ag) }
+
     config_attr :podspec,
       command_line: '--podspec FILEPATH',
       parse: ->(ps) { PodspecDocumenter.create_podspec(Pathname(ps)) if ps },

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -73,6 +73,10 @@ module Jazzy
       Pathname(path).expand_path(base_path) # nil means Pathname.pwd
     end
 
+    def glob_path(path)
+      Dir.glob(base_path + path)
+    end
+
     # ──────── Build ────────
 
     # rubocop:disable Style/AlignParameters
@@ -175,6 +179,11 @@ module Jazzy
       command_line: '--readme FILEPATH',
       description: 'The path to a markdown README file',
       parse: ->(rp) { expand_path(rp) }
+
+    config_attr :documentation_glob,
+      command_line: '--documentation GLOB',
+      description: 'Glob that matches available documentation',
+      parse: ->(dg) { glob_path(dg) }
 
     config_attr :podspec,
       command_line: '--podspec FILEPATH',

--- a/lib/jazzy/documentation_generator.rb
+++ b/lib/jazzy/documentation_generator.rb
@@ -1,0 +1,37 @@
+require 'pathname'
+
+require 'jazzy/jazzy_markdown'
+require 'jazzy/source_document'
+
+module Jazzy
+
+  module DocumentationGenerator
+    extend Config::Mixin
+
+    def self.source_docs
+      documentation_entries.map do |file_path|
+        SourceDocument.new.tap do |sd|
+          sd.name = File.basename(file_path, '.md')
+          sd.url = sd.name.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '') + ".html"
+          sd.type = SourceDeclaration::Type.new 'document.markdown'
+          sd.children = []
+          sd.overview = overview Pathname(file_path)
+          sd.usr = 'documentation.' + sd.name
+          sd.abstract = ''
+          sd.return = ''
+          sd.parameters = []
+        end
+      end
+    end
+
+    def self.overview file_path
+      return "" unless file_path && file_path.exist?
+      file_path.read
+    end
+
+    def self.documentation_entries
+      return [] unless config.documentation_glob_configured && config.documentation_glob
+      config.documentation_glob.select { |e| File.file? e }
+    end
+  end
+end

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -8,6 +8,14 @@ module Jazzy
     # static type of declared element (e.g. String.Type -> ())
     attr_accessor :typename
 
+    def is_type?(type_kind)
+      respond_to?(:type) && type.kind == type_kind
+    end
+
+    def render?
+      is_type?('document.markdown') || children.count != 0
+    end
+
     # Element containing this declaration in the code
     attr_accessor :parent_in_code
 

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -69,7 +69,22 @@ module Jazzy
     attr_accessor :nav_order
 
     def overview
-      "#{abstract}\n\n#{discussion}".strip
+      alternative_abstract || "#{abstract}\n\n#{discussion}".strip
+    end
+
+    def alternative_abstract
+      if file = alternative_abstract_file
+        Pathname(file).read
+      end
+    end
+
+    def alternative_abstract_file
+      abstract_glob.select { |f| File.basename(f).split('.').first == name }.first
+    end
+
+    def abstract_glob
+      return [] unless Config.instance.abstract_glob_configured && Config.instance.abstract_glob
+      Config.instance.abstract_glob.select { |e| File.file? e }
     end
   end
 end

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -90,8 +90,12 @@ module Jazzy
       end
 
       TYPES = {
-        # Objective-C
+        'document.markdown' => {
+          jazzy: 'Guide',
+          dash: 'Guide',
+        }.freeze,
 
+        # Objective-C
         'sourcekitten.source.lang.objc.decl.category' => {
           jazzy: 'Category',
           dash: 'Extension',

--- a/lib/jazzy/source_document.rb
+++ b/lib/jazzy/source_document.rb
@@ -5,6 +5,7 @@ require 'jazzy/jazzy_markdown'
 module Jazzy
 
   class SourceDocument < SourceDeclaration
+    extend Config::Mixin
 
     attr_accessor :overview
     attr_accessor :readme_path

--- a/lib/jazzy/source_document.rb
+++ b/lib/jazzy/source_document.rb
@@ -1,0 +1,69 @@
+require 'pathname'
+
+require 'jazzy/jazzy_markdown'
+
+module Jazzy
+
+  class SourceDocument < SourceDeclaration
+
+    attr_accessor :overview
+    attr_accessor :readme_path
+
+    def url
+      name.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '') + ".html"
+    end
+
+    def content(source_module)
+      return readme_content(source_module) if name == 'index'
+      overview
+    end
+
+    def readme_content(source_module)
+      config_readme || fallback_readme || generated_readme(source_module)
+    end
+
+    def config_readme
+      readme_path.read if readme_path && readme_path.exist?
+    end
+
+    def fallback_readme
+      %w(README.md README.markdown README.mdown README).each do |potential_name|
+        file = config.source_directory + potential_name
+        return file if file.exist?
+      end
+    end
+
+    def generated_readme(source_module)
+      if podspec = config.podspec
+        ### License
+
+        # <a href="#{license[:url]}">#{license[:license]}</a>
+        <<-EOS
+# #{podspec.name}
+
+### #{podspec.summary}
+
+#{podspec.description}
+
+### Installation
+
+```ruby
+pod '#{podspec.name}'
+```
+
+### Authors
+
+#{source_module.author_name}
+EOS
+      else
+        <<-EOS
+# #{source_module.name}
+
+### Authors
+
+#{source_module.author_name}
+EOS
+      end
+    end
+  end
+end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -476,11 +476,11 @@ module Jazzy
 
     # Parse sourcekitten STDOUT output as JSON
     # @return [Hash] structured docs
-    def self.parse(sourcekitten_output, min_acl, skip_undocumented)
+    def self.parse(sourcekitten_output, min_acl, skip_undocumented, inject_docs)
       @min_acl = min_acl
       @skip_undocumented = skip_undocumented
       sourcekitten_json = filter_excluded_files(JSON.parse(sourcekitten_output))
-      docs = make_source_declarations(sourcekitten_json)
+      docs = make_source_declarations(sourcekitten_json).concat inject_docs
       docs = ungrouped_docs = deduplicate_declarations(docs)
       docs = group_docs(docs)
       if Config.instance.objc_mode


### PR DESCRIPTION
Fixes: #435
Adds two configuration options:

- `--documentation`: A glob for extra documentation to be injected similar to readmes, but also listed in the sidebar.
- `--abstract`: A glob for injecting extra content into matching Abstract group sections.

P.S. This is pretty rough. I recommend discussing it's merits, rejecting and reworking it.