### PR TITLE
Add --head option to inject custom HTML into <head></head>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   projects.  
   [Jeff Verkoeyen](https://github.com/jverkoey)
 
+* Add `--head` option to inject custom HTML into `<head></head>`.  
+  [JP Simard](https://github.com/jpsim)
+
 ##### Bug Fixes
 
 * Fix an issue where extension documentation would use the original type

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -247,6 +247,11 @@ module Jazzy
                     'Example: http://git.io/v4Bcp'],
       default: []
 
+    config_attr :custom_head,
+      command_line: '--head HTML',
+      description: 'Custom HTML to inject into <head></head>.',
+      default: ''
+
     config_attr :theme_directory,
       command_line: '--theme [apple | fullwidth | DIRPATH]',
       description: "Which theme to use. Specify either 'apple' (default), "\

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -195,6 +195,7 @@ module Jazzy
       doc = Doc.new # Mustache model instance
       doc[:name] = source_module.name
       doc[:overview] = ReadmeGenerator.generate(source_module)
+      doc[:custom_head] = Config.instance.custom_head
       doc[:doc_coverage] = source_module.doc_coverage unless
         Config.instance.hide_documentation_coverage
       doc[:structure] = source_module.doc_structure
@@ -300,6 +301,7 @@ module Jazzy
       end
 
       doc = Doc.new # Mustache model instance
+      doc[:custom_head] = Config.instance.custom_head
       doc[:doc_coverage] = source_module.doc_coverage unless
         Config.instance.hide_documentation_coverage
       doc[:name] = doc_model.name

--- a/lib/jazzy/themes/apple/templates/doc.mustache
+++ b/lib/jazzy/themes/apple/templates/doc.mustache
@@ -7,6 +7,7 @@
     <meta charset='utf-8'>
     <script src="{{path_to_root}}js/jquery.min.js" defer></script>
     <script src="{{path_to_root}}js/jazzy.js" defer></script>
+    {{{custom_head}}}
   </head>
   <body>
     {{#dash_type}}

--- a/lib/jazzy/themes/fullwidth/templates/doc.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/doc.mustache
@@ -7,6 +7,7 @@
     <meta charset="utf-8">
     <script src="{{path_to_root}}js/jquery.min.js" defer></script>
     <script src="{{path_to_root}}js/jazzy.js" defer></script>
+    {{{custom_head}}}
   </head>
   <body>
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -90,6 +90,29 @@ describe_cli 'jazzy' do
 
   travis_swift = ENV['TRAVIS_SWIFT_VERSION']
 
+  require 'shellwords'
+  # rubocop:disable Metrics/LineLength
+  realm_head = <<-HTML
+<link rel="icon" href="https://realm.io/img/favicon.ico">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="https://realm.io/img/favicon-57x57.png" />
+<link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://realm.io/img/favicon-114x114.png" />
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://realm.io/img/favicon-72x72.png" />
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://realm.io/img/favicon-144x144.png" />
+<link rel="apple-touch-icon-precomposed" sizes="120x120" href="https://realm.io/img/favicon-120x120.png" />
+<link rel="apple-touch-icon-precomposed" sizes="152x152" href="https://realm.io/img/favicon-152x152.png" />
+<link rel="icon" type="image/png" href="https://realm.io/img/favicon-32x32.png" sizes="32x32" />
+<link rel="icon" type="image/png" href="https://realm.io/img/favicon-16x16.png" sizes="16x16" />
+<script defer>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  ga('create', 'UA-50247013-1', 'realm.io');
+  ga('send', 'pageview');
+</script>
+  HTML
+  # rubocop:enable Metrics/LineLength
+
   describe 'jazzy objective-c' do
     describe 'Creates Realm Objective-C docs' do
       realm_version = ''
@@ -112,7 +135,8 @@ describe_cli 'jazzy' do
                             '--root-url https://realm.io/docs/objc/' \
                             "#{realm_version}/api/ " \
                             '--umbrella-header Realm/Realm.h ' \
-                            '--framework-root .'
+                            '--framework-root . ' \
+                            "--head #{realm_head.shellescape}"
     end
   end
 
@@ -153,7 +177,8 @@ describe_cli 'jazzy' do
                             '--root-url https://realm.io/docs/swift/' \
                             "#{realm_version}/api/ " \
                             '--xcodebuild-arguments ' \
-                            '-scheme,RealmSwift'
+                            '-scheme,RealmSwift ' \
+                            "--head #{realm_head.shellescape}"
     end
 
     describe 'Creates docs for Swift project with a variety of contents' do


### PR DESCRIPTION
My main motivation for this is to avoid having to maintain a full fork of the theme, templates and assets in realm-cocoa, but this should be generally useful to others who want to do the same, especially injecting custom JS.