### PR TITLE
Config keys from command line opts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,9 @@ GuardClause:
 Next:
   Enabled: false
 
+RegexpLiteral:
+  EnforcedStyle: mixed
+
 #- Jazzy specs -----------------------------------------------------------#
 
 # Allow for `should.match /regexp/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Master
+
+##### Breaking
+
+* Config files now use the same option names as the command line. If you are
+  using one of the keys that has changed in your `.jazzy.yaml`, you will receive
+  a warning. See the [pull request](https://github.com/realm/jazzy/pull/456) for
+  a complete list of changed options. As always, you can get a list of all
+  options with `jazzy --help config`.
+  [pcantrell](https://github.com/pcantrell)
+
 ## 0.5.0
 
 ##### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   using one of the keys that has changed in your `.jazzy.yaml`, you will receive
   a warning. See the [pull request](https://github.com/realm/jazzy/pull/456) for
   a complete list of changed options. As always, you can get a list of all
-  options with `jazzy --help config`.
+  options with `jazzy --help config`.  
   [pcantrell](https://github.com/pcantrell)
 
 ## 0.5.0

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -11,7 +11,8 @@ module Jazzy
   class Config
     # rubocop:disable Style/AccessorMethodName
     class Attribute
-      attr_reader :name, :description, :command_line, :config_file_key, :default, :parse
+      attr_reader :name, :description, :command_line, :config_file_key,
+                  :default, :parse
 
       def initialize(name, description: nil, command_line: nil,
                      default: nil, parse: ->(x) { x })
@@ -57,18 +58,18 @@ module Jazzy
 
       private
 
-        def full_command_line_name
-          long_option_names = command_line.map do |opt|
-            $1 if opt =~ %r(
-              ^--           # starts with double dash
-              (?:\[no-\])?  # optional prefix for booleans
-              ([^\s]+)      # long option name
-            )x
-          end
-          if long_option_name = long_option_names.compact.first
-            long_option_name.gsub('-', '_')
-          end
+      def full_command_line_name
+        long_option_names = command_line.map do |opt|
+          Regexp.last_match(1) if opt =~ %r{
+            ^--           # starts with double dash
+            (?:\[no-\])?  # optional prefix for booleans
+            ([^\s]+)      # long option name
+          }x
         end
+        if long_option_name = long_option_names.compact.first
+          long_option_name.tr('-', '_')
+        end
+      end
     end
     # rubocop:enable Style/AccessorMethodName
 
@@ -366,14 +367,14 @@ module Jazzy
       attrs_by_conf_key, attrs_by_name = %i(config_file_key name).map do |prop|
         self.class.all_config_attrs.group_by(&prop)
       end
-        
+
       config_file.each do |key, value|
         unless attr = attrs_by_conf_key[key]
           message = "WARNING: Unknown config file attribute #{key.inspect}"
           if matching_name = attrs_by_name[key]
-            message << " (Did you mean "
+            message << ' (Did you mean '
             message << matching_name.first.config_file_key.inspect
-            message << "?)"
+            message << '?)'
           end
           warn message
           next

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -11,15 +11,16 @@ module Jazzy
   class Config
     # rubocop:disable Style/AccessorMethodName
     class Attribute
-      attr_reader :name, :description, :command_line, :default, :parse
+      attr_reader :name, :description, :command_line, :config_file_key, :default, :parse
 
       def initialize(name, description: nil, command_line: nil,
                      default: nil, parse: ->(x) { x })
-        @name = name
+        @name = name.to_s
         @description = Array(description)
         @command_line = Array(command_line)
         @default = default
         @parse = parse
+        @config_file_key = full_command_line_name || @name
       end
 
       def get(config)
@@ -53,6 +54,21 @@ module Jazzy
           set(config, val)
         end
       end
+
+      private
+
+        def full_command_line_name
+          long_option_names = command_line.map do |opt|
+            $1 if opt =~ %r(
+              ^--           # starts with double dash
+              (?:\[no-\])?  # optional prefix for booleans
+              ([^\s]+)      # long option name
+            )x
+          end
+          if long_option_name = long_option_names.compact.first
+            long_option_name.gsub('-', '_')
+          end
+        end
     end
     # rubocop:enable Style/AccessorMethodName
 
@@ -346,11 +362,24 @@ module Jazzy
 
       puts "Using config file #{config_path}"
       config_file = read_config_file(config_path)
-      self.class.all_config_attrs.each do |attr|
-        key = attr.name.to_s
-        if config_file.key?(key)
-          attr.set_if_unconfigured(self, config_file[key])
+
+      attrs_by_conf_key, attrs_by_name = %i(config_file_key name).map do |prop|
+        self.class.all_config_attrs.group_by(&prop)
+      end
+        
+      config_file.each do |key, value|
+        unless attr = attrs_by_conf_key[key]
+          message = "WARNING: Unknown config file attribute #{key.inspect}"
+          if matching_name = attrs_by_name[key]
+            message << " (Did you mean "
+            message << matching_name.first.config_file_key.inspect
+            message << "?)"
+          end
+          warn message
+          next
         end
+
+        attr.first.set_if_unconfigured(self, value)
       end
 
       self.base_path = nil
@@ -404,7 +433,7 @@ module Jazzy
           puts
           puts attr.name.to_s.tr('_', ' ').upcase
           puts
-          puts "  Config file:   #{attr.name}"
+          puts "  Config file:   #{attr.config_file_key}"
           cmd_line_forms = attr.command_line.select { |opt| opt.is_a?(String) }
           if cmd_line_forms.any?
             puts "  Command line:  #{cmd_line_forms.join(', ')}"

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -44,7 +44,6 @@ module Jazzy
                             Version
                             Warning).freeze
 
-    # rubocop:disable RegexpLiteral
     SPECIAL_LIST_TYPE_REGEX = %r{
       \A\s* # optional leading spaces
       (<p>\s*)? # optional opening p tag
@@ -52,7 +51,6 @@ module Jazzy
       (#{SPECIAL_LIST_TYPES.map(&Regexp.method(:escape)).join('|')})
       [\s:] # followed by either a space or a colon
     }ix
-    # rubocop:enable RegexpLiteral
 
     ELIDED_LI_TOKEN = '7wNVzLB0OYPL2eGlPKu8q4vITltqh0Y6DPZf659TPMAeYh49o'.freeze
 


### PR DESCRIPTION
Derives config file keys from command line options instead of property names. This results in the following changes:

- `objc_mode` → `objc`
- `config_file` → `config`
- `excluded_files` → `exclude`
- `author_name` → `author`
- `module_name` → `module`
- `version` → `module_version`
- `readme_path` → `readme`
- `custom_head` → `head`
- `theme_directory` → `theme`

This affects config files only, not command line options.

Old config file keys will no longer work, but jazzy emits a helpful warning:

    WARNING: Unknown config file attribute "module_name" (Did you mean "module"?)

That “Did you mean?” part requires a half dozen lines of extra code, which we might consider removing after this has been in place for a release or two.

This is all per a discussion thread which I now cannot find — probably because it was attached to a commit?

This may fix #448. 