### PR TITLE
Add Siesta to specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ begin
     files_glob = 'spec/integration_specs/*/after/{*,.*}'
     files_to_delete = FileList[files_glob]
       .exclude('**/.', '**/..')
-      .exclude('spec/integration_specs/*/after/docs',
+      .exclude('spec/integration_specs/*/after/*docs',
                'spec/integration_specs/*/after/execution_output.txt')
       .include('**/*.dsidx')
       .include('**/*.tgz')

--- a/Rakefile
+++ b/Rakefile
@@ -54,8 +54,9 @@ begin
 
     # Remove files not used for the comparison
     # To keep the git diff clean
-    files_glob = 'spec/integration_specs/*/after/{*,.git,.gitignore}'
+    files_glob = 'spec/integration_specs/*/after/{*,.*}'
     files_to_delete = FileList[files_glob]
+      .exclude('**/.', '**/..')
       .exclude('spec/integration_specs/*/after/docs',
                'spec/integration_specs/*/after/execution_output.txt')
       .include('**/*.dsidx')

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -181,6 +181,11 @@ describe_cli 'jazzy' do
                             "--head #{realm_head.shellescape}"
     end
 
+    describe 'Creates Siesta docs' do
+      behaves_like cli_spec 'document_siesta',
+                            '--output api-docs'  # Siesta already has Docs/
+    end
+
     describe 'Creates docs for Swift project with a variety of contents' do
       behaves_like cli_spec 'misc_jazzy_features',
                             '-x -dry-run --theme fullwidth'

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -183,7 +183,7 @@ describe_cli 'jazzy' do
 
     describe 'Creates Siesta docs' do
       behaves_like cli_spec 'document_siesta',
-                            '--output api-docs'  # Siesta already has Docs/
+                            '--output api-docs' # Siesta already has Docs/
     end
 
     describe 'Creates docs for Swift project with a variety of contents' do


### PR DESCRIPTION
Per a suggestion @jpsim made a while ago; finally getting around to it.

Also folded in a fix to remove all the spurious dotfiles in `after/` dirs, which weren’t being deleted by the rake task.