### PR TITLE
Merge ObjC categories into docs of the extended class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,10 @@ TrailingComma:
 Style/SpecialGlobalVars:
   Enabled: false
 
+# We prefer explicit `a, _ = arr` to `a, = arr` (which could be misread as a stray comma)
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
 # For lambdas nested within certain expressions, this rule forces either ugly
 # parens or curly braces that violate the "do/end for multiline blocks" rule.
 Lambda:

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -41,6 +41,13 @@ module Jazzy
       namespace_path.map(&:name).join('.')
     end
 
+    # If this declaration is an objc category, returns an array with the name
+    # of the extended objc class and the category name itself, i.e.
+    # ["NSString", "MyMethods"], nil otherwise.
+    def objc_category_name
+      name.split(/[\(\)]/) if type.objc_category?
+    end
+
     attr_accessor :file
     attr_accessor :line
     attr_accessor :column

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -40,6 +40,14 @@ module Jazzy
         kind == 'sourcekitten.source.lang.objc.decl.typedef'
       end
 
+      def objc_category?
+        kind == 'sourcekitten.source.lang.objc.decl.category'
+      end
+
+      def objc_class?
+        kind == 'sourcekitten.source.lang.objc.decl.class'
+      end
+
       def swift_enum_case?
         kind == 'source.lang.swift.decl.enumcase'
       end
@@ -55,6 +63,10 @@ module Jazzy
       def declaration?
         kind.start_with?('source.lang.swift.decl') ||
           kind.start_with?('sourcekitten.source.lang.objc.decl')
+      end
+
+      def extension?
+        swift_extension? || objc_category?
       end
 
       def swift_extension?

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -138,6 +138,11 @@ describe_cli 'jazzy' do
                             '--framework-root . ' \
                             "--head #{realm_head.shellescape}"
     end
+
+    describe 'Creates docs for ObjC project with a variety of contents' do
+      behaves_like cli_spec 'misc_jazzy_objc_features',
+                            '--theme fullwidth'
+    end
   end
 
   describe 'jazzy swift 2.1.1' do


### PR DESCRIPTION
This is work-in-progress on #457.

The idea was to annotate `SourceDeclaration`s representing extensions (both swift and objc) with a link to the parent declaration that is being extended, and then use this as a deduplication key. This kind of unifies the existing approach for swift extensions with new behaviour needed for objc classes/categories.

Furthermore, we found it nice to have category name appear as a mark of the merged methods.
