### PR TITLE
Add Swift 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ notifications:
   slack: realmio:vPdpsG9NLDo2DNlbqtcMAQuE
 matrix:
   include:
-    - osx_image: xcode7.2
-      env: TRAVIS_SWIFT_VERSION=2.1.1
+    - osx_image: xcode7.3
+      env: TRAVIS_SWIFT_VERSION=2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   format includes contextual information that one might use to lint
   documentation in an automated fashion.  
   [Jeff Verkoeyen](https://github.com/jverkoey)
+* Add Swift 2.2 support.  
+[Tamar Nachmany](https://github.com/tamarnachmany)
 
 ##### Enhancements
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -159,7 +159,7 @@ module Jazzy
 
     config_attr :swift_version,
       command_line: '--swift-version VERSION',
-      default: '2.1.1',
+      default: '2.2',
       parse: ->(v) do
         raise 'jazzy only supports Swift 2.0 or later.' if v.to_f < 2
         v

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -145,7 +145,7 @@ describe_cli 'jazzy' do
     end
   end
 
-  describe 'jazzy swift 2.1.1' do
+  describe 'jazzy swift 2.2' do
     describe 'Creates docs for a podspec with dependencies and subspecs' do
       behaves_like cli_spec 'document_moya_podspec', '--podspec=Moya.podspec'
     end
@@ -194,5 +194,5 @@ describe_cli 'jazzy' do
       behaves_like cli_spec 'misc_jazzy_features',
                             '-x -dry-run --theme fullwidth'
     end
-  end if !travis_swift || travis_swift == '2.1.1'
+  end if !travis_swift || travis_swift == '2.2'
 end


### PR DESCRIPTION
This PR provides Jazzy support to developers running Xcode 7.3. It changes all hard-coded references to Swift 2.1.1 and Xcode 7.2 to Swift 2.2 and Xcode 7.3.

Note: This is failing CI and I'm not sure why. Maybe Travis does not yet support Swift 2.2? I'm not familiar with it and use Jenkins myself. In any case, thought I would open this PR and hopefully we can sort through the CI fail and get this working for people! Also, I've never contributed here before, let me know if everything is set up correctly here.