### PR TITLE
Use `-` for Markdown slugs instead of `_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Master
+
+##### Bug Fixes
+
+* Uses GitHub-Flavored Markdown syntax for anchors when rendering README pages.  
+  [Zachary Waldowski](https://github.com/zwaldowski)
+  [#524](https://github.com/realm/jazzy/issues/524)
+
 ## 0.6.0
 
 ##### Breaking

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -8,10 +8,10 @@ module Jazzy
     include Rouge::Plugins::Redcarpet
 
     def header(text, header_level)
-      text_slug = text.gsub(/[^a-zA-Z0-9]+/, '_')
+      text_slug = text.gsub(/[^\w]+/, '-')
                       .downcase
-                      .sub(/^_/, '')
-                      .sub(/_$/, '')
+                      .sub(/^-/, '')
+                      .sub(/-$/, '')
 
       "<a href='##{text_slug}' class='anchor' aria-hidden=true>" \
         '<span class="header-anchor"></span>' \


### PR DESCRIPTION
See #524.

Requires spec updates. Workin' on it…