### PR TITLE
Add ability to exclude directories in addition to files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ##### Enhancements
 
-* Objective-C documentation now also includes Swift declarations.  
+* `--exclude` flag now supports excluding directories in addition to files.  
+  [Gurrinder](https://github.com/gurrinder)
+  [#503](https://github.com/realm/jazzy/issues/503)
+
+* Objective-C documentation now also includes Swift declarations.
   [JP Simard](https://github.com/jpsim)
   [#136](https://github.com/realm/jazzy/issues/136)
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -150,8 +150,8 @@ module Jazzy
       parse: ->(sd) { expand_path(sd) }
 
     config_attr :excluded_files,
-      command_line: ['-e', '--exclude file1,file2,…fileN', Array],
-      description: 'Files to be excluded from documentation',
+      command_line: ['-e', '--exclude file1,file2,directory3,…fileN', Array],
+      description: 'Files/directories to be excluded from documentation',
       default: [],
       parse: ->(files) do
         Array(files).map { |f| expand_path(f) }

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -409,7 +409,7 @@ module Jazzy
       excluded_files = Config.instance.excluded_files
       json.map do |doc|
         key = doc.keys.first
-        doc[key] unless excluded_files.detect{|file| File.fnmatch?(key, file)}
+        doc[key] unless excluded_files.detect { |f| File.fnmatch?(key, f) }
       end.compact
     end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -409,7 +409,7 @@ module Jazzy
       excluded_files = Config.instance.excluded_files
       json.map do |doc|
         key = doc.keys.first
-        doc[key] unless excluded_files.include?(Pathname(key))
+        doc[key] unless excluded_files.detect{|file| key.include? file.to_s}
       end.compact
     end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -409,7 +409,7 @@ module Jazzy
       excluded_files = Config.instance.excluded_files
       json.map do |doc|
         key = doc.keys.first
-        doc[key] unless excluded_files.detect{|file| key.include? file.to_s}
+        doc[key] unless excluded_files.detect{|file| File.fnmatch?(key, file)}
       end.compact
     end
 


### PR DESCRIPTION
Add ability to exclude directories in addition to files.
E.g. `exclude: ['Vendor/*']`
Related issue: https://github.com/realm/jazzy/issues/503