### PR TITLE
Escape question marks in URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ##### Bug Fixes
 
+* Escape ? in URLs.    
+  [Paul Taykalo](https://github.com/PaulTaykalo)
+  [#547](https://github.com/realm/jazzy/issues/547)
 * Uses GitHub-Flavored Markdown syntax for anchors when rendering README pages.  
   [Zachary Waldowski](https://github.com/zwaldowski)
   [#524](https://github.com/realm/jazzy/issues/524)

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -71,7 +71,7 @@ module Jazzy
           # Create HTML page for this doc if it has children or is root-level
           doc.url = (
             subdir_for_doc(doc) +
-            [doc.name + '.html']
+            [sanitize_doc_name(doc.name) + '.html']
           ).join('/')
           doc.children = make_doc_urls(doc.children)
         else
@@ -99,6 +99,13 @@ module Jazzy
       end
     end
     # rubocop:enable Metrics/MethodLength
+
+    # Sanitizes document name for using in URLS
+    def self.sanitize_doc_name(name)
+      # Replace question mark wich can be used as valid character in Swift operator
+      # to sequence which can't be used in  Swift functions
+      name.gsub("?", "q-")
+    end
 
     # Determine the subdirectory in which a doc should be placed
     def self.subdir_for_doc(doc)


### PR DESCRIPTION
 Source Kitten output could have question marks in document names when parsing Swift sources. Since we cannot use question marks in URLs, we need to escape them with some adequate characters sequence. `q` was added to represent question mark, and `-` was added since no potential function name can have dashes in it
