### PR TITLE
don't unconditionally document Swift extensions with MARKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 * Fix crash when using unexposed declarations in Objective-C.  
   [JP Simard](https://github.com/jpsim)
   [#543](https://github.com/realm/jazzy/issues/543)
+* No longer document Swift extensions on types with an ACL lower than `min-acl`
+  when they contain `MARK`s.  
+  [JP Simard](https://github.com/jpsim)
+  [#544](https://github.com/realm/jazzy/issues/544)
 
 ## 0.6.0
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -169,7 +169,8 @@ module Jazzy
       return true if type.swift_enum_element?
       if type.swift_extension?
         return Array(doc['key.substructure']).any? do |subdoc|
-          should_document?(subdoc)
+          subtype = SourceDeclaration::Type.new(subdoc['key.kind'])
+          !subtype.mark? && should_document?(subdoc)
         end
       end
 


### PR DESCRIPTION
Fixes #544