### PR TITLE
Improved lint report readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   [William Meleyal](https://github.com/meleyal)
   [#438](https://github.com/realm/jazzy/issues/438)
 
+* The lint report in `undocumented.json` is more human-readable: includes fully
+  qualified symbol names, pretty printed.  
+  [Paul Cantrell](https://github.com/pcantrell)
+  [#598](https://github.com/realm/jazzy/issues/598)
+
 ## 0.7.0
 
 ##### Breaking

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -180,7 +180,7 @@ module Jazzy
 
         lint_report = {
           warnings: warnings.sort_by do |w|
-            [w[:file], w[:line] || 0]
+            [w[:file], w[:line] || 0, w[:symbol_qualified]]
           end,
           source_directory: options.source_directory,
         }

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -182,7 +182,7 @@ module Jazzy
           warnings: warnings.sort_by do |w|
             [w[:file], w[:line] || 0]
           end,
-          source_directory: options.source_directory
+          source_directory: options.source_directory,
         }
         f.write(JSON.pretty_generate(lint_report))
       end

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -189,7 +189,7 @@ module Jazzy
           warnings: warnings,
           source_directory: options.source_directory
         }
-        f.write(lint_report.to_json)
+        f.write(JSON.pretty_generate(lint_report))
       end
     end
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -166,8 +166,7 @@ module Jazzy
         {
           file: decl.file,
           line: decl.line || decl.start_line,
-          symbol: decl.name,
-          symbol_qualified: decl.fully_qualified_name,
+          symbol: decl.fully_qualified_name,
           symbol_kind: decl.type.kind,
           warning: 'undocumented',
         }
@@ -180,7 +179,7 @@ module Jazzy
 
         lint_report = {
           warnings: warnings.sort_by do |w|
-            [w[:file], w[:line] || 0, w[:symbol_qualified], w[:symbol_kind]]
+            [w[:file], w[:line] || 0, w[:symbol], w[:symbol_kind]]
           end,
           source_directory: options.source_directory,
         }

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -166,7 +166,7 @@ module Jazzy
       decls_by_file.each_key do |file|
         decls_by_file[file].each do |decl|
           warnings << {
-            file: decl.file.basename,
+            file: decl.file,
             line: decl.line || decl.start_line,
             symbol: decl.name,
             symbol_kind: decl.type.kind,
@@ -187,12 +187,7 @@ module Jazzy
 
         lint_report = {
           warnings: warnings,
-          source_directory: (
-            if ENV['JAZZY_INTEGRATION_SPECS']
-              'Specs'
-            else
-              options.source_directory
-            end),
+          source_directory: options.source_directory
         }
         f.write(lint_report.to_json)
       end

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -169,6 +169,7 @@ module Jazzy
             file: decl.file,
             line: decl.line || decl.start_line,
             symbol: decl.name,
+            symbol_qualified: decl.fully_qualified_name,
             symbol_kind: decl.type.kind,
             warning: 'undocumented',
           }

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -32,7 +32,7 @@ module Jazzy
     def self.doc_structure_for_docs(docs)
       docs.map do |doc|
         children = doc.children
-                      .sort_by { |c| [c.nav_order, c.name] }
+                      .sort_by { |c| [c.nav_order, c.name, c.usr] }
                       .flat_map do |child|
           # FIXME: include arbitrarily nested extensible types
           [{ name: child.name, url: child.url }] +
@@ -180,7 +180,7 @@ module Jazzy
 
         lint_report = {
           warnings: warnings.sort_by do |w|
-            [w[:file], w[:line] || 0, w[:symbol_qualified]]
+            [w[:file], w[:line] || 0, w[:symbol_qualified], w[:symbol_kind]]
           end,
           source_directory: options.source_directory,
         }

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -60,6 +60,7 @@ module Jazzy
     attr_accessor :line
     attr_accessor :column
     attr_accessor :usr
+    attr_accessor :modulename
     attr_accessor :name
     attr_accessor :declaration
     attr_accessor :other_language_declaration

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -71,7 +71,8 @@ CLIntegracon.configure do |c|
 
   # Remove absolute paths from output
   c.transform_produced '**/undocumented.json' do |path|
-    File.write(path,
+    File.write(
+      path,
       File.read(path).gsub(
         (ROOT + 'tmp').to_s,
         '<TMP>'))

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -69,6 +69,14 @@ CLIntegracon.configure do |c|
   c.ignores %r{^(?!(docs/|execution_output.txt))}
   c.ignores '*.tgz'
 
+  # Remove absolute paths from output
+  c.transform_produced '**/undocumented.json' do |path|
+    File.write(path,
+      File.read(path).gsub(
+        (ROOT + 'tmp').to_s,
+        '<TMP>'))
+  end
+
   # Transform produced databases to csv
   c.transform_produced '**/*.dsidx' do |path|
     File.open("#{path}.csv", 'w') do |file|


### PR DESCRIPTION
This PR contains three improvements to make `undocumented.json` more useful & more human-readable:

- The file is now pretty printed.
- Warnings are sorted by (file, line) instead of the current somewhat haphazard ordering.
- There is a new `symbol_qualified` key that gives, for example, `"Error.Cause.UnencodableText.text"` instead of the no-so-useful `"text"`. (In a green field, I’d prefer to just replacing the existing `symbol` with that fully qualified value, but I left the old key/value intact in case anyone’s using it.)

[Here are the results.](https://github.com/realm/jazzy-integration-specs/blob/feb50ad01ce0f0f00018b4f150fd642d1cb57300/document_moya_podspec/after/docs/undocumented.json)

I know the intent was to run `undocumented.json` through some reporting tool, but it’s nice to also be able to read the file itself.

In the course of implementing this, I noticed that jazzy was generating the lint report using the raw Sourcekitten dict, which resulted in some redundant logic. I switched over to using the parsed `SourceDeclaration` object, and that cleaned up a few dozen lines of code. I put that change, the one that caused the most code disruption, in its [own commit](https://github.com/realm/jazzy/commit/9833412ea5f4eb129a3b11d2d2b1523f7402c007), and verified that it didn’t alter the integration specs. (I did, however, get [different spec output locally](https://github.com/realm/jazzy-integration-specs/commit/3b2620e6ca98d017b4ded7b1c7f3c5f9db3d154e) than was checked in even before making changes. Dependencies changed? Different Ruby? Different Sourcekitten? We’ll see what happens on CI….)