### PR TITLE
Fix abstract injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@
 * Podspec-based documentation respects the `swift-version` config option.  
   [Orta Therox](https://github.com/orta)
 
-##### Enhancements
-
-* None.
-
 ##### Bug Fixes
 
 * Rename Dash typedef type from "Alias" to "Type".  
@@ -27,6 +23,11 @@
   platforms.  
   [JP Simard](https://github.com/jpsim)
   [#661](https://github.com/realm/jazzy/issues/661)
+
+* Fix issue where existing abstracts for non custom sections would be
+  completely overwritten when using extra abstract injection with --abstract.  
+  [Thibaud Robelain](https://github.com/thibaudrobelain)
+  [#600](https://github.com/realm/jazzy/issues/600)
 
 ## 0.7.2
 

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -78,7 +78,7 @@ module Jazzy
     attr_accessor :nav_order
 
     def overview
-      alternative_abstract || "#{abstract}\n\n#{discussion}".strip
+      "#{alternative_abstract}\n\n#{abstract}\n\n#{discussion}".strip
     end
 
     def alternative_abstract


### PR DESCRIPTION
This fixes the behavior of --abstract as described in #600.
Integration specs currently point at my fork but I'll change that if we approve the new behavior!

This PR fixes the --abstract command when it's being used with existing sections that have an already existing abstract. The old behavior was to remove it and use the alternative abstract given from the .md file entirely, the new behavior (this PR) is to simply append the existing abstract after the alternative abstract.
