### PR TITLE
Bugfix/bugfix 518

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ##### Bug Fixes
 
+* Fix issue where header files are not found if inside subdirectories of the 
+  framework_root specified folder.
+  [Christopher Gretzki](https://github.com/gretzki)
+  [#518](https://github.com/realm/jazzy/issues/518)
+
 * Fix issue where jazzy could not be installed from Gemfile due to
   SourceKitten symlinks already being present.  
   [William Meleyal](https://github.com/meleyal)

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -124,6 +124,12 @@ module Jazzy
                         'objective-c', '-isysroot',
                         `xcrun --show-sdk-path --sdk #{options.sdk}`.chomp,
                         '-I', options.framework_root.to_s]
+          # add additional -I arguments for each subdirectory of framework_root
+          Pathname.new(options.framework_root.to_s).children.collect do |child|
+            if child.directory?
+              arguments += ['-I', child.to_s]
+            end
+          end
         end
       elsif !options.module_name.empty?
         arguments += ['--module-name', options.module_name, '--']

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -115,6 +115,15 @@ module Jazzy
       end
     end
 
+    # returns all subdirectories of specified path
+    def self.rec_path(path)
+      path.children.collect do |child|
+        if child.directory?
+          rec_path(child) + [child]
+        end
+      end.select { |x| x }.flatten(1)
+    end
+
     # Builds SourceKitten arguments based on Jazzy options
     def self.arguments_from_options(options)
       arguments = ['doc']
@@ -125,7 +134,9 @@ module Jazzy
                         `xcrun --show-sdk-path --sdk #{options.sdk}`.chomp,
                         '-I', options.framework_root.to_s]
           # add additional -I arguments for each subdirectory of framework_root
-          Pathname.new(options.framework_root.to_s).children.collect do |child|
+        end
+        unless options.framework_root.nil?
+          rec_path(Pathname.new(options.framework_root.to_s)).collect do |child|
             if child.directory?
               arguments += ['-I', child.to_s]
             end


### PR DESCRIPTION
Adding all subdirectories of specified "framework_root" option as argument to sourcekitten. This enables references inside the umbrella header to other source files that are within subdirectories of the "framework_root".
This solves issue #518 
