### PR TITLE
Fixed wildcards in file exclude config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   [Paul Cantrell](https://github.com/pcantrell)
   [#598](https://github.com/realm/jazzy/issues/598)
 
+* The `exclude` option now properly supports wildcards.  
+  [Paul Cantrell](https://github.com/pcantrell)
+  [#640](https://github.com/realm/jazzy/issues/640)
+
 ## 0.7.0
 
 ##### Breaking

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -151,7 +151,8 @@ module Jazzy
 
     config_attr :excluded_files,
       command_line: ['-e', '--exclude file1,file2,directory3,…fileN', Array],
-      description: 'Files/directories to be excluded from documentation. Supports wildcards.',
+      description: 'Files/directories to be excluded from documentation. '\
+                   'Supports wildcards.',
       default: [],
       parse: ->(files) do
         Array(files).map { |f| expand_path(f).to_s }

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -151,7 +151,7 @@ module Jazzy
 
     config_attr :excluded_files,
       command_line: ['-e', '--exclude file1,file2,directory3,…fileN', Array],
-      description: 'Files/directories to be excluded from documentation',
+      description: 'Files/directories to be excluded from documentation. Supports wildcards.',
       default: [],
       parse: ->(files) do
         Array(files).map { |f| expand_path(f).to_s }

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -154,7 +154,7 @@ module Jazzy
       description: 'Files/directories to be excluded from documentation',
       default: [],
       parse: ->(files) do
-        Array(files).map { |f| expand_path(f) }
+        Array(files).map { |f| expand_path(f).to_s }
       end
 
     config_attr :swift_version,

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -417,7 +417,7 @@ module Jazzy
       excluded_files = Config.instance.excluded_files
       json.map do |doc|
         key = doc.keys.first
-        doc[key] unless excluded_files.detect { |f| File.fnmatch?(key, f) }
+        doc[key] unless excluded_files.detect { |exclude| File.fnmatch?(exclude, key) }
       end.compact
     end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -417,7 +417,9 @@ module Jazzy
       excluded_files = Config.instance.excluded_files
       json.map do |doc|
         key = doc.keys.first
-        doc[key] unless excluded_files.detect { |exclude| File.fnmatch?(exclude, key) }
+        doc[key] unless excluded_files.detect do |exclude|
+          File.fnmatch?(exclude, key)
+        end
       end.compact
     end
 


### PR DESCRIPTION
The `exclude` config option is clearly intended to support wildcards, but they weren’t working because:

- the crucial call to `fnmatch?` passed the arguments in the wrong order and
- one of them was a Pathname instead of a string.

This PR makes wildcard excludes work as expected. The corresponding specs update adds a [regression test for wildcards](https://github.com/realm/jazzy-integration-specs/commit/570dc142cff5170572554bde320d08e4d6a709e5).

The specs were not passing when I checked them out. I just regenerated them to match what jazzy was producing without further investigation. [Here’s what changed.](https://github.com/realm/jazzy-integration-specs/commit/84836e5777c3c2588e204cb5bfaa099a94966290)