### PR TITLE
treat an ACL of 'open' as more public than 'public'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   [JP Simard](https://github.com/jpsim)
   [#654](https://github.com/realm/jazzy/issues/654)
 
+* Treat the `open` ACL as more public than `public`.  
+  [JP Simard](https://github.com/jpsim)
+
 ## 0.7.1
 
 ##### Breaking

--- a/lib/jazzy/source_declaration/access_control_level.rb
+++ b/lib/jazzy/source_declaration/access_control_level.rb
@@ -82,8 +82,8 @@ module Jazzy
         private: 0,
         fileprivate: 1,
         internal: 2,
-        open: 3,
-        public: 4,
+        public: 3,
+        open: 4,
       }.freeze
 
       def <=>(other)


### PR DESCRIPTION
Otherwise `open` declarations won't be documented by default.