### PR TITLE
Fixed link to Travis build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![analytics](https://ga-beacon.appspot.com/UA-50247013-2/jazzy/README?pixel)
 
-![Test Status](https://travis-ci.org/realm/jazzy.svg?branch=master)
+[![Build Status](https://travis-ci.org/realm/jazzy.svg?branch=master)](https://travis-ci.org/realm/jazzy)
 
 *jazzy is a command-line utility that generates documentation for Swift or Objective-C*
 


### PR DESCRIPTION
New link leads to Travis status page, not just SVG status image.
Should I add anything to Changelog or is it fine?