### PR TITLE
[Podspec] Improve support for podspec based documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Master
+
+##### Enhancements
+
+* Podspec-based documentation will take trunk's `pushed_with_swift_version`
+  attribute into account when generating documentation by default.  
+  [Orta Therox](https://github.com/orta)
+
+* Podspec-based documentation respects the `swift-version` config option.  
+  [Orta Therox](https://github.com/orta)
+
 ## 0.7.2
 
 ##### Breaking

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -57,7 +57,8 @@ module Jazzy
         stdout = options.sourcekitten_sourcefile.read
       else
         if options.podspec_configured
-          stdout = PodspecDocumenter.new(options.podspec).sourcekitten_output
+          pod_documenter = PodspecDocumenter.new(options.podspec)
+          stdout = pod_documenter.sourcekitten_output(options)
         else
           stdout = Dir.chdir(options.source_directory) do
             arguments = SourceKitten.arguments_from_options(options)


### PR DESCRIPTION
Two main parts as a part of migrating CocoaDocs to support Swift 3 properly. Fixes https://github.com/CocoaPods/cocoadocs.org/issues/473

* Podspec-based documentation will take trunk's `pushed_with_swift_version`
  attribute into account when generating documentation by default.  

* Podspec-based documentation respects the `swift-version` config option.  

