### PR TITLE
Move Code of Conduct out of README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,3 @@
+# Code of Conduct
+
 Jazzy conforms to the [Realm Code of Conduct](https://realm.io/conduct). By participating, contributing or using Jazzy, you are expected to uphold this code. Please report unacceptable behavior to [info@realm.io](mailto:info@realm.io).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+Jazzy conforms to the [Realm Code of Conduct](https://realm.io/conduct). By participating, contributing or using Jazzy, you are expected to uphold this code. Please report unacceptable behavior to [info@realm.io](mailto:info@realm.io).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,27 @@
-## Tracking changes
+# Code of Conduct
 
-All changes should be made via pull requests on GitHub.
+Please read the [Code of Conduct](CODE_OF_CONDUCT.md) document before contributing.
 
-When issuing a pull request, please add a summary of your changes to
-the `CHANGELOG.md` file.
+# Tracking Changes
+
+All changes must be merged in via a pull request on GitHub. When issuing a pull request, please add a summary of your changes to the `CHANGELOG.md` file.
 
 We follow the same syntax as CocoaPods' CHANGELOG.md:
 
-1. One Markdown unnumbered list item desribing the change.
-2. 2 trailing spaces on the last line describing the change.
-3. A list of Markdown hyperlinks to the contributors to the change. One entry
-   per line. Usually just one.
-4. A list of Markdown hyperlinks to the issues the change addresses. One entry
-   per line. Usually just one. Don't link to PRs here.
-5. All CHANGELOG.md content is hard-wrapped at 80 characters.
+1. A markdown unnumbered list item describing the change(s).
+2. Two trailing spaces on the last line describing the change.
+3. A list of markdown hyperlinks to the contributors of the change.
+    - One entry per line, although usually just one.
+4. A list of markdown hyperlinks to the issues that the change addresses.
+    - One entry per line, although usually just one.
+    - Try to not link to PRs here.
+5. All `CHANGELOG.md` content is hard-wrapped at 80 characters.
 
-## Updating the integration specs
+# Updating the Integration Specs
 
-Jazzy heavily relies on integration tests, but since they're considerably large
-and noisy, we keep them in a separate repo
-([realm/jazzy-integration-specs](https://github.com/realm/jazzy-integration-specs)).
+Jazzy heavily relies on integration tests, but since they're considerably large and noisy, we keep them in a separate repo ([realm/jazzy-integration-specs](https://github.com/realm/jazzy-integration-specs)).
 
-If you're making a PR towards jazzy that affects the generated docs, please
+If you're making a PR towards Jazzy that affects the generated docs, please
 update the integration specs using the following process:
 
 ```shell
@@ -31,7 +31,7 @@ git checkout -
 git rebase master
 bundle install
 bundle exec rake rebuild_integration_fixtures
-cd spec/integration_specs
+cd spec/integration_specs/
 git checkout -b $jazzy_branch_name
 git commit -a -m "update for $jazzy_branch_name"
 git push
@@ -46,12 +46,12 @@ request access from one of the maintainers when filing your PR.
 ## Making changes to SourceKitten
 
 When changes are landed in the https://github.com/jpsim/SourceKitten repo the
-SourceKitten framework located in jazzy must be updated.
+SourceKitten framework located in Jazzy must be updated.
 
 The following may be executed from your `jazzy/` directory.
 
 ```
-cd SourceKitten
+cd SourceKitten/
 git checkout master
 git pull
 cd ..

--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ of Apple’s official reference documentation, post WWDC 2014.
 
 ![Screenshot](images/screenshot.jpg)
 
-This project adheres to the [Contributor Covenant Code of Conduct](https://realm.io/conduct).
-By participating, you are expected to uphold this code. Please report
-unacceptable behavior to [info@realm.io](mailto:info@realm.io).
-
 ## Requirements
 
 * A version of [Xcode][xcode] (6.x or 7.x) capable of building the project


### PR DESCRIPTION
I prefer to have the Code of Conduct in its own file. Gives it the attention it needs rather than hiding or making people look for it. Moved it out of `README.md`, created a file `CODE_OF_CONDUCT.md` and added a link to the Code of Conduct to the top of `CONTRIBUTING.md`. Let me know what y'all think.