### PR TITLE
Add Code of Conduct details to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+## Code of Conduct
+
+This project adheres to the [Contributor Covenant Code of Conduct](https://realm.io/conduct).
+By participating, you are expected to uphold this code. Please report
+unacceptable behavior to [info@realm.io](mailto:info@realm.io).
+
 ## Tracking changes
 
 All changes should be made via pull requests on GitHub.


### PR DESCRIPTION
This change was discussed in #682. Instead of removing the Code of Conduct out of the `README`, that section has just been duplicated and added to the `CONTRIBUTING.md` file.