### PR TITLE
Rename Dash typedef type from "Alias" to "Type"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
 * Podspec-based documentation respects the `swift-version` config option.  
   [Orta Therox](https://github.com/orta)
 
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
+* Rename Dash typedef type from "Alias" to "Type".  
+  [Bogdan Popescu](https://github.com/Kapeli)
+
 ## 0.7.2
 
 ##### Breaking

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -159,7 +159,7 @@ module Jazzy
         }.freeze,
         'sourcekitten.source.lang.objc.decl.typedef' => {
           jazzy: 'Type Definition',
-          dash: 'Alias',
+          dash: 'Type',
         }.freeze,
         'sourcekitten.source.lang.objc.mark' => {
           jazzy: 'Mark',


### PR DESCRIPTION
Continued from #596.