### PR TITLE
fix crash when sorting declarations with no USR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+##### Breaking
+
+* None.
+
 ##### Enhancements
 
 * Podspec-based documentation will take trunk's `pushed_with_swift_version`
@@ -17,6 +21,12 @@
 
 * Rename Dash typedef type from "Alias" to "Type".  
   [Bogdan Popescu](https://github.com/Kapeli)
+
+* Fix crash when sorting multiple identically named declarations with no USR,
+  which is very common when generating docs for podspecs supporting multiple
+  platforms.  
+  [JP Simard](https://github.com/jpsim)
+  [#661](https://github.com/realm/jazzy/issues/661)
 
 ## 0.7.2
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -32,7 +32,7 @@ module Jazzy
     def self.doc_structure_for_docs(docs)
       docs.map do |doc|
         children = doc.children
-                      .sort_by { |c| [c.nav_order, c.name, c.usr] }
+                      .sort_by { |c| [c.nav_order, c.name, c.usr || ''] }
                       .flat_map do |child|
           # FIXME: include arbitrarily nested extensible types
           [{ name: child.name, url: child.url }] +


### PR DESCRIPTION
since usr isn't present in all declarations, we need to fall back on something.

fixes #661.