### PR TITLE
Fix #429 generic type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   [Thibaud Robelain](https://github.com/thibaudrobelain)
   [#600](https://github.com/realm/jazzy/issues/600)
 
-* Fix issue where generic type parameters registered as undocumented symbols.
+* Fix issue where generic type parameters registered as undocumented symbols.  
   [Jeremy David Giesbrecht](https://github.com/SDGGiesbrecht)
   [#429](https://github.com/realm/jazzy/issues/429)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   [Thibaud Robelain](https://github.com/thibaudrobelain)
   [#600](https://github.com/realm/jazzy/issues/600)
 
+* Fix issue where generic type parameters registered as undocumented symbols.
+  [Jeremy David Giesbrecht](https://github.com/SDGGiesbrecht)
+  [#429](https://github.com/realm/jazzy/issues/429)
+
 ## 0.7.3
 
 ##### Breaking

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -203,7 +203,9 @@ module Jazzy
       filepath = doc['key.filepath']
       objc = Config.instance.objc_mode
       if filepath && (filepath.start_with?(source_directory) || objc)
-        @undocumented_decls << declaration
+        if doc['key.kind'] != 'source.lang.swift.decl.generic_type_param'
+          @undocumented_decls << declaration
+        end
       end
       return nil if !documented_child?(doc) && @skip_undocumented
       make_default_doc_info(declaration)


### PR DESCRIPTION
Fixes issue #429 by filtering out instances of `source.lang.swift.decl.generic_type_param` and ignoring those undocumented symbols. Unless I am mistaken, it is not currently possible to document such a symbol even if one wanted to. You can see the difference in action by running the test in [my last comment on the issue](https://github.com/realm/jazzy/issues/429#issuecomment-266245903).