### PR TITLE
Fix #673 duplicate callouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   [Thibaud Robelain](https://github.com/thibaudrobelain)
   [#600](https://github.com/realm/jazzy/issues/600)
 
+* Fix issue where parameter and return callouts where duplicated in documentation.  
+  [Jeremy David Giesbrecht](https://github.com/SDGGiesbrecht)
+  [#673]
+
 ## 0.7.3
 
 ##### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * Fix issue where parameter and return callouts where duplicated in documentation.  
   [Jeremy David Giesbrecht](https://github.com/SDGGiesbrecht)
-  [#673]
+  [#673](https://github.com/realm/jazzy/issues/673)
 
 ## 0.7.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   [Thibaud Robelain](https://github.com/thibaudrobelain)
   [#600](https://github.com/realm/jazzy/issues/600)
 
-* Fix issue where parameter and return callouts where duplicated in documentation.  
+* Fix issue where parameter and return callouts were duplicated in documentation.  
   [Jeremy David Giesbrecht](https://github.com/SDGGiesbrecht)
   [#673](https://github.com/realm/jazzy/issues/673)
 

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -18,31 +18,32 @@ module Jazzy
       '</a>' \
       "<h#{header_level} id='#{text_slug}'>#{text}</h#{header_level}>\n"
     end
-
-    SPECIAL_LIST_TYPES = %w(Attention
-                            Author
-                            Authors
-                            Bug
-                            Complexity
-                            Copyright
-                            Date
-                            Experiment
-                            Important
-                            Invariant
-                            Note
-                            Parameter
-                            Postcondition
-                            Precondition
-                            Remark
-                            Requires
-                            Returns
-                            See
-                            SeeAlso
-                            Since
-                            TODO
-                            Throws
-                            Version
-                            Warning).freeze
+    
+    UNIQUELY_HANDLED_SPECIAL_LIST_TYPES = %w(Parameters
+                                             Parameter
+                                             Returns).freeze
+    SPECIAL_LIST_TYPES = (UNIQUELY_HANDLED_SPECIAL_LIST_TYPES + %w(Attention
+                                                                   Author
+                                                                   Authors
+                                                                   Bug
+                                                                   Complexity
+                                                                   Copyright
+                                                                   Date
+                                                                   Experiment
+                                                                   Important
+                                                                   Invariant
+                                                                   Note
+                                                                   Postcondition
+                                                                   Precondition
+                                                                   Remark
+                                                                   Requires
+                                                                   See
+                                                                   SeeAlso
+                                                                   Since
+                                                                   TODO
+                                                                   Throws
+                                                                   Version
+                                                                   Warning)).freeze
 
     SPECIAL_LIST_TYPE_REGEX = %r{
       \A\s* # optional leading spaces
@@ -57,7 +58,7 @@ module Jazzy
     def list_item(text, _list_type)
       if text =~ SPECIAL_LIST_TYPE_REGEX
         type = Regexp.last_match(2)
-        return ELIDED_LI_TOKEN if type =~ /parameter|returns/
+        return ELIDED_LI_TOKEN if UNIQUELY_HANDLED_SPECIAL_LIST_TYPES.include? type.capitalize
         return render_aside(type, text.sub(/#{Regexp.escape(type)}:\s+/, ''))
       end
       str = '<li>'

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -18,32 +18,33 @@ module Jazzy
       '</a>' \
       "<h#{header_level} id='#{text_slug}'>#{text}</h#{header_level}>\n"
     end
-    
-    UNIQUELY_HANDLED_SPECIAL_LIST_TYPES = %w(Parameters
-                                             Parameter
-                                             Returns).freeze
-    SPECIAL_LIST_TYPES = (UNIQUELY_HANDLED_SPECIAL_LIST_TYPES + %w(Attention
-                                                                   Author
-                                                                   Authors
-                                                                   Bug
-                                                                   Complexity
-                                                                   Copyright
-                                                                   Date
-                                                                   Experiment
-                                                                   Important
-                                                                   Invariant
-                                                                   Note
-                                                                   Postcondition
-                                                                   Precondition
-                                                                   Remark
-                                                                   Requires
-                                                                   See
-                                                                   SeeAlso
-                                                                   Since
-                                                                   TODO
-                                                                   Throws
-                                                                   Version
-                                                                   Warning)).freeze
+
+    UNIQUELY_HANDLED_CALLOUTS = %w(Parameters
+                                   Parameter
+                                   Returns).freeze
+    GENERAL_CALLOUTS = %w(Attention
+                          Author
+                          Authors
+                          Bug
+                          Complexity
+                          Copyright
+                          Date
+                          Experiment
+                          Important
+                          Invariant
+                          Note
+                          Postcondition
+                          Precondition
+                          Remark
+                          Requires
+                          See
+                          SeeAlso
+                          Since
+                          TODO
+                          Throws
+                          Version
+                          Warning).freeze
+    SPECIAL_LIST_TYPES = (UNIQUELY_HANDLED_CALLOUTS + GENERAL_CALLOUTS).freeze
 
     SPECIAL_LIST_TYPE_REGEX = %r{
       \A\s* # optional leading spaces
@@ -58,7 +59,9 @@ module Jazzy
     def list_item(text, _list_type)
       if text =~ SPECIAL_LIST_TYPE_REGEX
         type = Regexp.last_match(2)
-        return ELIDED_LI_TOKEN if UNIQUELY_HANDLED_SPECIAL_LIST_TYPES.include? type.capitalize
+        if UNIQUELY_HANDLED_CALLOUTS.include? type.capitalize
+          return ELIDED_LI_TOKEN
+        end
         return render_aside(type, text.sub(/#{Regexp.escape(type)}:\s+/, ''))
       end
       str = '<li>'


### PR DESCRIPTION
Fixed #673 by normalizing capitalization before filtering special callouts (Parameter, Returns). Also added the callout Parameters for consistency. (See the list of callouts in Swift’s [API Design Guidelines](https://swift.org/documentation/api-design-guidelines/#write-doc-comment.))

You can run the following commands to see the problem. (You’ll have to manually expand one of the functions once the documentation pops up.)

```shell
git clone https://github.com/SDGGiesbrecht/SDGLogic
cd SDGLogic
swift package generate-xcodeproj
jazzy
open docs/Functions.html
cd ..
```

Run the commands again with jazzy built from this branch and you will see that the duplicate callouts are gone.