### PR TITLE
Autolink Objective-C qualified method references in abstracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Enhancements
 
-* None.
+* Fully qualified references to Objective-C methods are now autolinked.  
+  [Minh Nguyễn](https://github.com/1ec5)
+  [#362](https://github.com/realm/jazzy/issues/362)
 
 ##### Bug Fixes
 


### PR DESCRIPTION
Fully qualified references to Objective-C methods are now autolinked in abstracts when surrounded by backticks. The following syntaxes are supported:

* `+[RLMRealm defaultRealm]`
* `-[RLMRealm writeCopyToPath:encryptionKey:error:]`

I punted on the `[RLMRealm defaultRealm]` syntax because of the increased risk of accidentally linking something that isn’t a method reference. But supporting it would be straightforward: the regular expressions would make the ± optional and try to match either kind of child, preferring the class method before the instance method in the event of ambiguity.

Fixes #362.

/cc @friedbunny @tmcw