### PR TITLE
Autolink Objective-C superclass in class declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
   [Jeremy David Giesbrecht](https://github.com/SDGGiesbrecht)
   [#673](https://github.com/realm/jazzy/issues/673)
 
+* Fix issue where Objective-C superclass in declaration was unlinked.  
+  [Minh Nguyễn](https://github.com/1ec5)
+  [#706](https://github.com/realm/jazzy/issues/706)
+
 ## 0.7.3
 
 ##### Breaking

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -14,7 +14,7 @@ ELIDED_AUTOLINK_TOKEN = '36f8f5912051ae747ef441d6511ca4cb'.freeze
 def autolink_regex(middle_regex, after_highlight)
   start_tag_re, end_tag_re =
     if after_highlight
-      [/<span class="(?:n|kt)">/, '</span>']
+      [/<span class="(?:n|kt|nc)">/, '</span>']
     else
       ['<code>', '</code>']
     end


### PR DESCRIPTION
In Objective-C class declarations, autolink the superclass if possible.

Fixes #706.

/cc @friedbunny @tmcw