### PR TITLE
Fix text replacement error

### DIFF
--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -533,10 +533,11 @@ module Jazzy
         name_root = ancestor_name_match(subject, doc) ||
                     name_match(subject, root_decls)
 
-        return [nil, raw_name] unless name_root
-        # Look up the verb in the subject’s children
-        verb = match[1] + match[3]
-        name_match(verb, name_root.children)
+        if name_root
+          # Look up the verb in the subject’s children
+          verb = match[1] + match[3]
+          name_match(verb, name_root.children)
+        end
       end
     end
 


### PR DESCRIPTION
This PR fixes an error that occurs whenever a Objective-C abstract or discussion contains a qualified reference to a method outside the module being documented. For example, the error in #711 occurred because of references like `-[NSNumber numberWithDouble:]`.

In Ruby, a `return` statement inside a closure apparently exits the surrounding method. In this case, that meant returning an array in a method that was expected to return a string. (The closure was supposed to generate a string, too.)

Fixes #711.