### PR TITLE
Autolink more Objective-C methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   [#361](https://github.com/realm/jazzy/issues/361)
   [#547](https://github.com/realm/jazzy/issues/547)
 
-* Fully qualified references to Objective-C methods are now autolinked.  
+* References to Objective-C methods are now autolinked.  
   [Minh Nguyễn](https://github.com/1ec5)
   [#362](https://github.com/realm/jazzy/issues/362)
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -534,12 +534,12 @@ module Jazzy
 
         # Traverse children via subsequence components, if any
         name_traversal(parts, name_root)
-      end.autolink_block(doc.url, '[+-]\[\w+ [\w:]+\]',
+      end.autolink_block(doc.url, '[+-]\[\w+(?: ?\(\w+\))? [\w:]+\]',
                          after_highlight) do |raw_name|
-        match = raw_name.match(/([+-])\[(\w+) ([\w:]+)\]/)
+        match = raw_name.match(/([+-])\[(\w+(?: ?\(\w+\))?) ([\w:]+)\]/)
 
         # Subject component can match any ancestor or top-level doc
-        subject = match[2]
+        subject = match[2].gsub(' ', '')
         name_root = ancestor_name_match(subject, doc) ||
                     name_match(subject, root_decls)
 
@@ -548,6 +548,12 @@ module Jazzy
           verb = match[1] + match[3]
           name_match(verb, name_root.children)
         end
+      end.autolink_block(doc.url, '[+-]\w[\w:]*',
+                         after_highlight) do |raw_name|
+        match = raw_name.match(/([+-])(\w[\w:]*)/)
+
+        verb = match[1] + match[2]
+        name_match(verb, doc.children)
       end
     end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -539,21 +539,16 @@ module Jazzy
         match = raw_name.match(/([+-])\[(\w+(?: ?\(\w+\))?) ([\w:]+)\]/)
 
         # Subject component can match any ancestor or top-level doc
-        subject = match[2].gsub(' ', '')
+        subject = match[2].delete(' ')
         name_root = ancestor_name_match(subject, doc) ||
                     name_match(subject, root_decls)
 
         if name_root
           # Look up the verb in the subject’s children
-          verb = match[1] + match[3]
-          name_match(verb, name_root.children)
+          name_match(match[1] + match[3], name_root.children)
         end
-      end.autolink_block(doc.url, '[+-]\w[\w:]*',
-                         after_highlight) do |raw_name|
-        match = raw_name.match(/([+-])(\w[\w:]*)/)
-
-        verb = match[1] + match[2]
-        name_match(verb, doc.children)
+      end.autolink_block(doc.url, '[+-]\w[\w:]*', after_highlight) do |raw_name|
+        name_match(raw_name, doc.children)
       end
     end
 


### PR DESCRIPTION
Autolink the following Objective-C method reference syntaxes:

* `+defaultRealm`
* `-writeCopyToPath:encryptionKey:error:`
* `+[NSValue(MGLAdditions) valueWithMGLLineJoin:]`
* `+[NSValue (MGLAdditions) valueWithMGLLineJoin:]`

Fixes #362.

/cc @friedbunny