### PR TITLE
Simplify integration spec update instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,7 @@ git checkout master
 git pull
 git checkout -
 git rebase master
-git submodule update --init --recursive
-bundle install
+rake bootstrap
 bundle exec rake rebuild_integration_fixtures
 cd spec/integration_specs
 git checkout -b $jazzy_branch_name


### PR DESCRIPTION
It turns out there’s a [`rake bootstrap`](https://github.com/realm/jazzy/blob/558803e7ec6bef25347a17e6550899dbaab33c52/Rakefile#L1-L18) command that manages `bundle install` and submodule initialization, so I’ve gone ahead and updated the spec update instructions to use that.

/cc @captainbarbosa