### PR TITLE
Print coverage percentage and undocumented count in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   [Minh Nguyễn](https://github.com/1ec5)
   [#362](https://github.com/realm/jazzy/issues/362)
 
+* Print documentation coverage percentage and the number of undocumented
+  methods to the command line when running jazzy.  
+  [Jason Wray](https://github.com/friedbunny)
+  [#724](https://github.com/realm/jazzy/issues/724)
+
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,6 @@
 * Print documentation coverage percentage and the number of undocumented
   methods to the command line when running jazzy.  
   [Jason Wray](https://github.com/friedbunny)
-  [#724](https://github.com/realm/jazzy/issues/724)
-
 
 ##### Bug Fixes
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -148,6 +148,10 @@ module Jazzy
       prepare_output_dir(options.output, options.clean)
       write_lint_report(undocumented, options)
 
+      puts "#{coverage}\% documentation coverage " \
+        "with #{undocumented.count} undocumented symbol" \
+        "#{undocumented.count == 1 ? '' : 's'}"
+
       unless options.skip_documentation
         build_site(docs, coverage, options)
       end


### PR DESCRIPTION
Adds the documentation coverage percentage and the count of undocumented symbols to the command line output. E.g., “X% documentation coverage with X undocumented symbol[s]”.

```
Using config file /mapbox-gl-native/platform/ios/jazzy.yml
89% documentation coverage with 74 undocumented symbols
building site
jam out ♪♫ to your fresh new docs in `documentation`
```

**Notes**
- This changes the execution output and will need the integration specs updated — happy to do this.
- Prints even if `skip-undocumented` and/or `hide_documentation_coverage` are specified.

/cc @1ec5