### PR TITLE
Generate badges displaying doc coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ##### Enhancements
 
+* Generate shields.io badge for documentation coverage, unless
+  `hide_documentation_coverage` is set.  
+  [Harlan Haskins](https://github.com/harlanhaskins)
+  [#723](https://github.com/realm/jazzy/issues/723)
+
 * Add support for searching docs when using the `fullwidth` theme. A new option,
   `--disable-search`, lets you turn this off.  
   [Esad Hajdarevic](https://github.com/esad)

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -114,12 +114,7 @@ module Jazzy
 
       structure = doc_structure_for_docs(docs)
 
-      docs << SourceDocument.new.tap do |sd|
-        sd.name = 'index'
-        sd.children = []
-        sd.type = SourceDeclaration::Type.new 'document.markdown'
-        sd.readme_path = options.readme_path
-      end
+      docs << SourceDocument.make_index(options.readme_path)
 
       source_module = SourceModule.new(options, docs, structure, coverage)
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -135,7 +135,7 @@ module Jazzy
 
       DocsetBuilder.new(output_dir, source_module).build!
 
-      download_badge(source_module, options)
+      download_badge(source_module.doc_coverage, options)
 
       friendly_path = relative_path_if_inside(output_dir, Pathname.pwd)
       puts "jam out ♪♫ to your fresh new docs in `#{friendly_path}`"
@@ -240,7 +240,7 @@ module Jazzy
 
     # Returns the appropriate color for the provided percentage,
     # used for generating a badge on shields.io
-    # @param [Number] coverage The documentation percentage
+    # @param [Number] coverage The documentation coverage percentage
     def self.color_for_coverage(coverage)
       if coverage < 10
         return 'red'
@@ -258,23 +258,22 @@ module Jazzy
     end
 
     # Downloads an SVG from shields.io displaying the documentation percentage
-    # @param [SourceModule] source_module The source module from SourceKitten
+    # @param [Number] coverage The documentation coverage percentage
     # @param [Config] options Build options
-    def self.download_badge(source_module, options)
-      if options.hide_documentation_coverage then
+    def self.download_badge(coverage, options)
+      if options.hide_documentation_coverage
         return
       end
-      color = self.color_for_coverage(source_module.doc_coverage)
-      uri = URI.parse("https://img.shields.io")
-      url_path = "/badge/documentation-" +
-                 "#{source_module.doc_coverage}%25-#{color}.svg"
+      warn 'downloading coverage badge'
+      color = color_for_coverage(coverage)
+      uri = URI.parse('https://img.shields.io')
+      url_path = "/badge/documentation-#{coverage}%25-#{color}.svg"
       Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
         resp = http.get url_path
-        File.open(options.output + "badge.svg", "wb") do |file|
+        File.open(options.output + 'badge.svg', 'wb') do |file|
           file.write resp.body
         end
       end
-      warn 'downloaded badge'
     end
 
     def self.should_link_to_github(file)

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -268,7 +268,7 @@ module Jazzy
       color = color_for_coverage(coverage)
       uri = URI.parse('https://img.shields.io')
       url_path = "/badge/documentation-#{coverage}%25-#{color}.svg"
-      Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         resp = http.get url_path
         File.open(options.output + 'badge.svg', 'wb') do |file|
           file.write resp.body

--- a/lib/jazzy/source_document.rb
+++ b/lib/jazzy/source_document.rb
@@ -7,6 +7,15 @@ module Jazzy
     attr_accessor :overview
     attr_accessor :readme_path
 
+    def self.make_index(readme_path)
+       SourceDocument.new.tap do |sd|
+        sd.name = 'index'
+        sd.children = []
+        sd.type = SourceDeclaration::Type.new 'document.markdown'
+        sd.readme_path = readme_path
+      end
+    end
+
     def config
       Config.instance
     end


### PR DESCRIPTION
This will generate badges using https://shields.io displaying the coverage percentage.
The color for the badge will be determined by this table:

| Percentage | Color |
|------------|-------|
| > 90% | brightgreen |
| 85% < x < 90% | green |
| 60% < x < 85% | yellowgreen |
| 30% < x < 60% | yellow |
| 10% < x < 30% | orange |
| < 10% | red |

This is an untested work in progress until I can get the project building locally.

Fixes #723.