### PR TITLE
Replace <q> tags with quotation marks in code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@
   [Minh Nguyễn](https://github.com/1ec5)
   [#539](https://github.com/realm/jazzy/issues/539)
 
+* String literals in code listings are no longer wrapped in `<q>` tags (`apple`
+  and `fullwidth` themes only).
+  [Minh Nguyễn](https://github.com/1ec5)
+  [#714](https://github.com/realm/jazzy/issues/714)
+
 ## 0.7.3
 
 ##### Breaking

--- a/lib/jazzy/themes/apple/assets/js/jazzy.js
+++ b/lib/jazzy/themes/apple/assets/js/jazzy.js
@@ -38,3 +38,9 @@ $(".token").click(function(event) {
   }
   event.preventDefault();
 });
+
+// Dumb down quotes within code blocks that delimit strings instead of quotations
+// https://github.com/realm/jazzy/issues/714
+$("code q").replaceWith(function () {
+  return ["\"", $(this).contents(), "\""];
+});

--- a/lib/jazzy/themes/fullwidth/assets/js/jazzy.js
+++ b/lib/jazzy/themes/fullwidth/assets/js/jazzy.js
@@ -35,3 +35,9 @@ $(".token").click(function(event) {
   }
   event.preventDefault();
 });
+
+// Dumb down quotes within code blocks that delimit strings instead of quotations
+// https://github.com/realm/jazzy/issues/714
+$("code q").replaceWith(function () {
+  return ["\"", $(this).contents(), "\""];
+});


### PR DESCRIPTION
Work around #714 by replacing `<q>` tags inside `<code>` tags with ASCII double quotation marks in JavaScript.

Upstreamed from mapbox/mapbox-gl-native#7629.

/cc @friedbunny