### PR TITLE
Add YAML.safe_load guard for Ruby 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   [Jason Wray](https://github.com/friedbunny)
   [#752](https://github.com/realm/jazzy/issues/752)
 
+* Fix support for Ruby 2.0.0.
+  [Jason Wray](https://github.com/friedbunny)
+  [#747](https://github.com/realm/jazzy/issues/747)
+
 ## 0.7.4
 
 ##### Breaking

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -431,7 +431,12 @@ module Jazzy
     def read_config_file(file)
       case File.extname(file)
         when '.json'         then JSON.parse(File.read(file))
-        when '.yaml', '.yml' then YAML.safe_load(File.read(file))
+        when '.yaml', '.yml' then
+          if YAML.respond_to?('safe_load') # ruby >= 2.1.0
+            YAML.safe_load(File.read(file))
+          else
+            YAML.load(File.read(file))
+          end
         else raise "Config file must be .yaml or .json, but got #{file.inspect}"
       end
     end

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -435,7 +435,9 @@ module Jazzy
           if YAML.respond_to?('safe_load') # ruby >= 2.1.0
             YAML.safe_load(File.read(file))
           else
+            # rubocop:disable Security/YAMLLoad
             YAML.load(File.read(file))
+            # rubocop:enable Security/YAMLLoad
           end
         else raise "Config file must be .yaml or .json, but got #{file.inspect}"
       end


### PR DESCRIPTION
Fixes #747 by re-adding support for Ruby 2.0.0.