### PR TITLE
Fix custom theme path expansion under Ruby 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix issue where using a custom theme would crash jazzy when using Ruby 2.4.
+  [Jason Wray](https://github.com/friedbunny)
+  [#752](https://github.com/realm/jazzy/issues/752)
 
 ## 0.7.4
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -295,8 +295,11 @@ module Jazzy
                    'other assets for a custom theme.',
       default: 'apple',
       parse: ->(t) do
-        return expand_path(t) unless t == 'apple' || t == 'fullwidth'
-        Pathname(__FILE__).parent + 'themes' + t
+        if t == 'apple' || t == 'fullwidth'
+          Pathname(__FILE__).parent + 'themes' + t
+        else
+          expand_path(t)
+        end
       end
 
     config_attr :use_safe_filenames,


### PR DESCRIPTION
Fixes #752. When using jazzy with Ruby 2.4, it fails hard when returning inside a block, so convert to a simple if-else expression.