### PR TITLE
Prevent Duplicated Lint Reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ##### Breaking
 
-* None.
+* `undocumented.json` is now only in the output directory and is no longer
+  copied into docsets.  
+  [Jeremy David Giesbrecht](https://github.com/SDGGiesbrecht)
+  [#754](https://github.com/realm/jazzy/issues/754)
 
 ##### Enhancements
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -151,7 +151,6 @@ module Jazzy
       )
 
       prepare_output_dir(options.output, options.clean)
-      write_lint_report(undocumented, options)
 
       puts "#{coverage}\% documentation coverage " \
         "with #{undocumented.count} undocumented symbol" \
@@ -160,6 +159,8 @@ module Jazzy
       unless options.skip_documentation
         build_site(docs, coverage, options)
       end
+
+      write_lint_report(undocumented, options)
     end
 
     def self.relative_path_if_inside(path, base_path)


### PR DESCRIPTION
This was discussed in #754.

With this pull request, “undocumented.json” is generated after building the site, so it is not yet present when the site is copied and gzipped for docsets.

This will require updates to the specs repository. I will try that right away.