### PR TITLE
Change markdown header html to stop corruption - issue 628

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Headers in source code markdown no longer cause corruption.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#628](https://github.com/realm/jazzy/issues/628)
 
 ## 0.7.5
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -305,25 +305,21 @@ module Jazzy
       abstract = (item.abstract || '') + (item.discussion || '')
       item_render = {
         name:                       item.name,
-        abstract:                   render_markdown(abstract),
+        abstract:                   abstract,
         declaration:                item.declaration,
         other_language_declaration: item.other_language_declaration,
         usr:                        item.usr,
         dash_type:                  item.type.dash_type,
         github_token_url:           gh_token_url(item, source_module),
-        default_impl_abstract:      render_markdown(item.default_impl_abstract),
+        default_impl_abstract:      item.default_impl_abstract,
         from_protocol_extension:    item.from_protocol_extension,
-        return:                     render_markdown(item.return),
+        return:                     item.return,
         parameters:                 (item.parameters if item.parameters.any?),
         url:                        (item.url if item.children.any?),
         start_line:                 item.start_line,
         end_line:                   item.end_line,
       }
       item_render.reject { |_, v| v.nil? }
-    end
-
-    def self.render_markdown(markdown)
-      Jazzy.markdown.render(markdown) if markdown
     end
 
     def self.make_task(mark, uid, items)
@@ -368,6 +364,12 @@ module Jazzy
         return document_markdown(source_module, doc_model, path_to_root)
       end
 
+      overview = (doc_model.abstract || '') + (doc_model.discussion || '')
+      alternative_abstract = doc_model.alternative_abstract
+      if alternative_abstract
+        overview = Jazzy.markdown.render(alternative_abstract) + overview
+      end
+
       doc = Doc.new # Mustache model instance
       doc[:custom_head] = Config.instance.custom_head
       doc[:disable_search] = Config.instance.disable_search
@@ -377,7 +379,7 @@ module Jazzy
       doc[:kind] = doc_model.type.name
       doc[:dash_type] = doc_model.type.dash_type
       doc[:declaration] = doc_model.declaration
-      doc[:overview] = Jazzy.markdown.render(doc_model.overview)
+      doc[:overview] = overview
       doc[:structure] = source_module.doc_structure
       doc[:tasks] = render_tasks(source_module, doc_model.children)
       doc[:module_name] = source_module.name

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -13,10 +13,9 @@ module Jazzy
                       .sub(/^-/, '')
                       .sub(/-$/, '')
 
-      "<a href='##{text_slug}' class='anchor' aria-hidden=true>" \
-        '<span class="header-anchor"></span>' \
-      '</a>' \
-      "<h#{header_level} id='#{text_slug}'>#{text}</h#{header_level}>\n"
+      "<h#{header_level} id='#{text_slug}' class='heading'>" \
+        "#{text}" \
+      "</h#{header_level}>\n"
     end
 
     # List from

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -77,10 +77,6 @@ module Jazzy
     attr_accessor :end_line
     attr_accessor :nav_order
 
-    def overview
-      "#{alternative_abstract}\n\n#{abstract}\n\n#{discussion}".strip
-    end
-
     def alternative_abstract
       if file = alternative_abstract_file
         Pathname(file).read

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -48,6 +48,7 @@ module Jazzy
   module SourceKitten
     @documented_count = 0
     @undocumented_decls = []
+    @default_abstract = Jazzy.markdown.render('Undocumented').freeze
 
     # Group root-level docs by custom categories (if any) and type
     def self.group_docs(docs)
@@ -93,7 +94,7 @@ module Jazzy
         SourceDeclaration.new.tap do |sd|
           sd.type     = SourceDeclaration::Type.overview
           sd.name     = name
-          sd.abstract = abstract
+          sd.abstract = Jazzy.markdown.render(abstract)
           sd.children = group
         end
       end
@@ -221,7 +222,7 @@ module Jazzy
       # @todo: Fix these
       declaration.line = nil
       declaration.column = nil
-      declaration.abstract = 'Undocumented'
+      declaration.abstract = @default_abstract
       declaration.parameters = []
       declaration.children = []
     end
@@ -497,7 +498,7 @@ module Jazzy
           end
           unless defaults.empty?
             proto_method.default_impl_abstract =
-              defaults.flat_map { |d| [d.abstract, d.discussion] }.join("\n\n")
+              defaults.flat_map { |d| [d.abstract, d.discussion] }.join
           end
         end
       end


### PR DESCRIPTION
Found this on the way to fixing something else...

See issues #628 and #630: a header in source code markdown can cause subsequent markup to be munged.  This happens when Jazzy sends the html 'abstract' generated by SourceKitten.make_doc_info() back through Redcarpet in DocBuilder.render_item().  The problem is that Redcarpet does html passthrough only for block elements. JazzyHTML.header() generates a sequence starting `<a>`.  This is not a block element and so things go poorly for everything up to the next blank line.

I’m pretty sure the `<a>` parts don't do anything and aren't required -- looks like a legacy of importing the github readme format into jazzy many moons ago.  So taking it out fixes these issues and has less html.  All the examples I have/can find look identical.

(I can't follow why jazzy needs to run the html item abstract through Redcarpet.  Maybe some item abstracts can be markdown here?? Insight appreciated.)

If you'd like this change then I will go ahead with the integration-specs part -- wondered if I could take them up to Xcode 8.3 first (different PR maybe?  8.3 results look OK to me: a few changed USRs and it picks up a previously missed typealias in Moya.)