### PR TITLE
Fix alignment of heading hyperlinks in apple theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ##### Bug Fixes
 
+* Linking to headers in apple theme gives correct vertical alignment.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 * Headers in source code markdown no longer cause corruption.  
   [John Fairhurst](https://github.com/johnfairh)
   [#628](https://github.com/realm/jazzy/issues/628)

--- a/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
@@ -262,6 +262,13 @@ header {
         padding-top: 15px;
       }
     }
+
+    .heading:before {
+      content: "";
+      display: block;
+      padding-top: $content_top_offset;
+      margin: -$content_top_offset 0 0;
+    }
   }
 }
 


### PR DESCRIPTION
Using the apple theme, following hyperlinks to markdown headings leads to the page being vertically scrolled too far up the page, so you can't see the heading.  This PR adds a fix to the CSS to take the height of the apple theme fixed header into account.  This is already present + working for the declaration anchors.

Affects specs only because they all include a copy of the CSS.  Will open a specs PR to match.