### PR TITLE
Don't require blank lines in markdown before lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ##### Bug Fixes
 
+* Blank line no longer needed before lists or code blocks.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#546](https://github.com/realm/jazzy/issues/546)
+
 * Linking to headers in apple theme gives correct vertical alignment.  
   [John Fairhurst](https://github.com/johnfairh)
 

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -103,6 +103,7 @@ module Jazzy
       strikethrough: true,
       space_after_headers: false,
       tables: true,
+      lax_spacing: true,
     }.freeze
   end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -66,7 +66,7 @@ CLIntegracon.configure do |c|
   # Ignore certain OSX files
   c.ignores '.DS_Store'
   c.ignores '.git'
-  c.ignores %r{^(?!(docs/|execution_output.txt))}
+  c.ignores %r{^(?!((api-)?docs/|execution_output.txt))}
   c.ignores '*.tgz'
 
   # Remove absolute paths from output


### PR DESCRIPTION
From at least #546.

Redcarpet has a flag called ‘lax_spacing’ which is documented as being to do with html.  From [the code](https://github.com/vmg/redcarpet/blob/68bfb5b79a08de4ee16e06905f27adb25eabbbe9/ext/redcarpet/markdown.c#L1660), this flag also stops redcarpet from requiring a blank line before lists and backticks-code blocks as well as before html.  The flag has no other effect.

Setting the flag means that redcarpet behaves in the same way as Xcode’s parser and how many humans (including this one) expect things to work.

Specs changed: this change fixed the parsing of a couple of mistakes (missing blank lines) in Siesta and I added a new test file.  Specs PR on the way.