### PR TITLE
Allow all markdown in param and returns callouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Enhancements
 
-* None.
+* Allow all markdown in returns and parameter description callouts.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#476](https://github.com/realm/jazzy/issues/476)
 
 ##### Bug Fixes
 

--- a/lib/jazzy/doc.rb
+++ b/lib/jazzy/doc.rb
@@ -19,7 +19,7 @@ module Jazzy
         "&copy; #{year} [#{config.author_name}](#{config.author_url}). " \
         "All rights reserved. (Last updated: #{date})"
       )
-      Jazzy.copyright_markdown.render(copyright).chomp
+      Markdown.render_copyright(copyright).chomp
     end
 
     def jazzy_version

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -220,7 +220,7 @@ module Jazzy
       doc = Doc.new # Mustache model instance
       name = doc_model.name == 'index' ? source_module.name : doc_model.name
       doc[:name] = name
-      doc[:overview] = Jazzy.markdown.render(doc_model.content(source_module))
+      doc[:overview] = Markdown.render(doc_model.content(source_module))
       doc[:custom_head] = Config.instance.custom_head
       doc[:disable_search] = Config.instance.disable_search
       doc[:doc_coverage] = source_module.doc_coverage unless
@@ -366,7 +366,7 @@ module Jazzy
       overview = (doc_model.abstract || '') + (doc_model.discussion || '')
       alternative_abstract = doc_model.alternative_abstract
       if alternative_abstract
-        overview = Jazzy.markdown.render(alternative_abstract) + overview
+        overview = Markdown.render(alternative_abstract) + overview
       end
 
       doc = Doc.new # Mustache model instance

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -3,99 +3,102 @@ require 'rouge'
 require 'rouge/plugins/redcarpet'
 
 module Jazzy
-  class JazzyHTML < Redcarpet::Render::HTML
-    include Redcarpet::Render::SmartyPants
-    include Rouge::Plugins::Redcarpet
+  module Markdown
+    class JazzyHTML < Redcarpet::Render::HTML
+      include Redcarpet::Render::SmartyPants
+      include Rouge::Plugins::Redcarpet
 
-    def header(text, header_level)
-      text_slug = text.gsub(/[^\w]+/, '-')
-                      .downcase
-                      .sub(/^-/, '')
-                      .sub(/-$/, '')
+      def header(text, header_level)
+        text_slug = text.gsub(/[^\w]+/, '-')
+                        .downcase
+                        .sub(/^-/, '')
+                        .sub(/-$/, '')
 
-      "<h#{header_level} id='#{text_slug}' class='heading'>" \
-        "#{text}" \
-      "</h#{header_level}>\n"
-    end
-
-    # List from
-    # https://github.com/apple/swift/blob/master/include/swift/Markup/SimpleFields.def
-    UNIQUELY_HANDLED_CALLOUTS = %w(parameters
-                                   parameter
-                                   returns).freeze
-    GENERAL_CALLOUTS = %w(attention
-                          author
-                          authors
-                          bug
-                          complexity
-                          copyright
-                          date
-                          experiment
-                          important
-                          invariant
-                          keyword
-                          mutatingvariant
-                          nonmutatingvariant
-                          note
-                          postcondition
-                          precondition
-                          recommended
-                          recommendedover
-                          remark
-                          remarks
-                          requires
-                          see
-                          seealso
-                          since
-                          todo
-                          throws
-                          version
-                          warning).freeze
-    SPECIAL_LIST_TYPES = (UNIQUELY_HANDLED_CALLOUTS + GENERAL_CALLOUTS).freeze
-
-    SPECIAL_LIST_TYPE_REGEX = %r{
-      \A\s* # optional leading spaces
-      (<p>\s*)? # optional opening p tag
-      # any one of our special list types
-      (#{SPECIAL_LIST_TYPES.map(&Regexp.method(:escape)).join('|')})
-      [\s:] # followed by either a space or a colon
-    }ix
-
-    ELIDED_LI_TOKEN = '7wNVzLB0OYPL2eGlPKu8q4vITltqh0Y6DPZf659TPMAeYh49o'.freeze
-
-    def list_item(text, _list_type)
-      if text =~ SPECIAL_LIST_TYPE_REGEX
-        type = Regexp.last_match(2)
-        if UNIQUELY_HANDLED_CALLOUTS.include? type.downcase
-          return ELIDED_LI_TOKEN
-        end
-        return render_aside(type, text.sub(/#{Regexp.escape(type)}:\s+/, ''))
+        "<h#{header_level} id='#{text_slug}' class='heading'>" \
+          "#{text}" \
+        "</h#{header_level}>\n"
       end
-      str = '<li>'
-      str << text.strip
-      str << "</li>\n"
-    end
 
-    def render_aside(type, text)
-      <<-HTML
+      # List from
+      # https://github.com/apple/swift/blob/master/include/swift/Markup/SimpleFields.def
+      UNIQUELY_HANDLED_CALLOUTS = %w(parameters
+                                     parameter
+                                     returns).freeze
+      GENERAL_CALLOUTS = %w(attention
+                            author
+                            authors
+                            bug
+                            complexity
+                            copyright
+                            date
+                            experiment
+                            important
+                            invariant
+                            keyword
+                            mutatingvariant
+                            nonmutatingvariant
+                            note
+                            postcondition
+                            precondition
+                            recommended
+                            recommendedover
+                            remark
+                            remarks
+                            requires
+                            see
+                            seealso
+                            since
+                            todo
+                            throws
+                            version
+                            warning).freeze
+      SPECIAL_LIST_TYPES = (UNIQUELY_HANDLED_CALLOUTS + GENERAL_CALLOUTS).freeze
+
+      SPECIAL_LIST_TYPE_REGEX = %r{
+        \A\s* # optional leading spaces
+        (<p>\s*)? # optional opening p tag
+        # any one of our special list types
+        (#{SPECIAL_LIST_TYPES.map(&Regexp.method(:escape)).join('|')})
+        [\s:] # followed by either a space or a colon
+      }ix
+
+      ELIDED_LI_TOKEN =
+        '7wNVzLB0OYPL2eGlPKu8q4vITltqh0Y6DPZf659TPMAeYh49o'.freeze
+
+      def list_item(text, _list_type)
+        if text =~ SPECIAL_LIST_TYPE_REGEX
+          type = Regexp.last_match(2)
+          if UNIQUELY_HANDLED_CALLOUTS.include? type.downcase
+            return ELIDED_LI_TOKEN
+          end
+          return render_aside(type, text.sub(/#{Regexp.escape(type)}:\s+/, ''))
+        end
+        str = '<li>'
+        str << text.strip
+        str << "</li>\n"
+      end
+
+      def render_aside(type, text)
+        <<-HTML
 <div class="aside aside-#{type.underscore.tr('_', '-')}">
     <p class="aside-title">#{type.underscore.humanize}</p>
     #{text}
 </div>
-      HTML
+        HTML
+      end
+
+      def list(text, list_type)
+        elided = text.gsub!(ELIDED_LI_TOKEN, '')
+        return if text =~ /\A\s*\Z/ && elided
+        return text if text =~ /class="aside-title"/
+        str = "\n"
+        str << (list_type == :ordered ? "<ol>\n" : "<ul>\n")
+        str << text
+        str << (list_type == :ordered ? "</ol>\n" : "</ul>\n")
+      end
     end
 
-    def list(text, list_type)
-      elided = text.gsub!(ELIDED_LI_TOKEN, '')
-      return if text =~ /\A\s*\Z/ && elided
-      return text if text =~ /class="aside-title"/
-      str = "\n"
-      str << (list_type == :ordered ? "<ol>\n" : "<ul>\n")
-      str << text
-      str << (list_type == :ordered ? "</ol>\n" : "</ul>\n")
-    end
-
-    OPTIONS = {
+    REDCARPET_OPTIONS = {
       autolink: true,
       fenced_code_blocks: true,
       no_intra_emphasis: true,
@@ -105,83 +108,87 @@ module Jazzy
       tables: true,
       lax_spacing: true,
     }.freeze
-  end
 
-  # Spot and capture returns & param HTML for separate display.
-  class JazzyDeclarationHTML < JazzyHTML
-    attr_reader :returns, :parameters
+    # Spot and capture returns & param HTML for separate display.
+    class JazzyDeclarationHTML < JazzyHTML
+      attr_reader :returns, :parameters
 
-    def reset
-      @returns = nil
-      @parameters = {}
-    end
-
-    INTRO_PAT = '\A(?<intro>\s*(<p>\s*)?)'.freeze
-    OUTRO_PAT = '(?<outro>.*)\z'.freeze
-
-    RETURNS_REGEX = /#{INTRO_PAT}returns:#{OUTRO_PAT}/im
-
-    IDENT_PAT = '(?<param>\S+)'.freeze
-
-    # Param formats: normal swift, objc via sourcekitten, and
-    # possibly inside 'Parameters:'
-    PARAM_PAT1 = "(parameter +#{IDENT_PAT}\\s*:)".freeze
-    PARAM_PAT2 = "(parameter:\\s*#{IDENT_PAT}\\s+)".freeze
-    PARAM_PAT3 = "(#{IDENT_PAT}\\s*:)".freeze
-
-    PARAM_PAT = "(?:#{PARAM_PAT1}|#{PARAM_PAT2}|#{PARAM_PAT3})".freeze
-
-    PARAM_REGEX = /#{INTRO_PAT}#{PARAM_PAT}#{OUTRO_PAT}/im
-
-    def list_item(text, _list_type)
-      if text =~ RETURNS_REGEX
-        @returns = render_param_returns(Regexp.last_match)
-      elsif text =~ PARAM_REGEX
-        @parameters[Regexp.last_match(:param)] =
-          render_param_returns(Regexp.last_match)
+      def reset
+        @returns = nil
+        @parameters = {}
       end
-      super
+
+      INTRO_PAT = '\A(?<intro>\s*(<p>\s*)?)'.freeze
+      OUTRO_PAT = '(?<outro>.*)\z'.freeze
+
+      RETURNS_REGEX = /#{INTRO_PAT}returns:#{OUTRO_PAT}/im
+
+      IDENT_PAT = '(?<param>\S+)'.freeze
+
+      # Param formats: normal swift, objc via sourcekitten, and
+      # possibly inside 'Parameters:'
+      PARAM_PAT1 = "(parameter +#{IDENT_PAT}\\s*:)".freeze
+      PARAM_PAT2 = "(parameter:\\s*#{IDENT_PAT}\\s+)".freeze
+      PARAM_PAT3 = "(#{IDENT_PAT}\\s*:)".freeze
+
+      PARAM_PAT = "(?:#{PARAM_PAT1}|#{PARAM_PAT2}|#{PARAM_PAT3})".freeze
+
+      PARAM_REGEX = /#{INTRO_PAT}#{PARAM_PAT}#{OUTRO_PAT}/im
+
+      def list_item(text, _list_type)
+        if text =~ RETURNS_REGEX
+          @returns = render_param_returns(Regexp.last_match)
+        elsif text =~ PARAM_REGEX
+          @parameters[Regexp.last_match(:param)] =
+            render_param_returns(Regexp.last_match)
+        end
+        super
+      end
+
+      def render_param_returns(matches)
+        body = matches[:intro].strip + matches[:outro].strip
+        body = "<p>#{body}</p>" unless body.start_with?('<p>')
+        Redcarpet::Render::SmartyPants.render(body)
+      end
     end
 
-    def render_param_returns(matches)
-      body = matches[:intro].strip + matches[:outro].strip
-      body = "<p>#{body}</p>" unless body.start_with?('<p>')
-      Redcarpet::Render::SmartyPants.render(body)
+    def self.renderer
+      @renderer ||= JazzyDeclarationHTML.new
     end
-  end
 
-  def self.markdown_renderer
-    @renderer ||= JazzyDeclarationHTML.new
-  end
+    def self.markdown
+      @markdown ||= Redcarpet::Markdown.new(renderer, REDCARPET_OPTIONS)
+    end
 
-  def self.markdown
-    @markdown ||= Redcarpet::Markdown.new(markdown_renderer, JazzyHTML::OPTIONS)
-  end
+    def self.render(markdown_text)
+      renderer.reset
+      markdown.render(markdown_text)
+    end
 
-  def self.render_declaration(body_markdown)
-    markdown_renderer.reset
-    markdown.render(body_markdown)
-  end
+    def self.rendered_returns
+      renderer.returns
+    end
 
-  def self.declaration_returns
-    markdown_renderer.returns
-  end
+    def self.rendered_parameters
+      renderer.parameters
+    end
 
-  def self.declaration_parameters
-    markdown_renderer.parameters
-  end
-
-  class JazzyCopyright < Redcarpet::Render::HTML
-    def link(link, _title, content)
-      %(<a class="link" href="#{link}" target="_blank" \
+    class JazzyCopyright < Redcarpet::Render::HTML
+      def link(link, _title, content)
+        %(<a class="link" href="#{link}" target="_blank" \
 rel="external">#{content}</a>)
+      end
     end
-  end
 
-  def self.copyright_markdown
-    @copyright_markdown ||= Redcarpet::Markdown.new(
-      JazzyCopyright,
-      JazzyHTML::OPTIONS,
-    )
+    def self.copyright_markdown
+      @copyright_markdown ||= Redcarpet::Markdown.new(
+        JazzyCopyright,
+        REDCARPET_OPTIONS,
+      )
+    end
+
+    def self.render_copyright(markdown_text)
+      copyright_markdown.render(markdown_text)
+    end
   end
 end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -301,11 +301,12 @@ module Jazzy
       end.join
     end
 
-    def self.parameters(doc)
+    def self.parameters(doc, discovered)
       (doc['key.doc.parameters'] || []).map do |p|
+        name = p['name']
         {
-          name: p['name'],
-          discussion: make_paragraphs(p, 'discussion'),
+          name: name,
+          discussion: discovered[name],
         }
       end
     end
@@ -329,11 +330,11 @@ module Jazzy
         )
       end
 
-      declaration.abstract = Jazzy.markdown.render(doc['key.doc.comment'] || '')
+      declaration.abstract =
+        Jazzy.render_declaration(doc['key.doc.comment'] || '')
       declaration.discussion = ''
-      declaration.return = make_paragraphs(doc, 'key.doc.result_discussion')
-
-      declaration.parameters = parameters(doc)
+      declaration.return = Jazzy.declaration_returns
+      declaration.parameters = parameters(doc, Jazzy.declaration_parameters)
 
       @documented_count += 1
     end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -48,7 +48,7 @@ module Jazzy
   module SourceKitten
     @documented_count = 0
     @undocumented_decls = []
-    @default_abstract = Jazzy.markdown.render('Undocumented').freeze
+    @default_abstract = Markdown.render('Undocumented').freeze
 
     # Group root-level docs by custom categories (if any) and type
     def self.group_docs(docs)
@@ -94,7 +94,7 @@ module Jazzy
         SourceDeclaration.new.tap do |sd|
           sd.type     = SourceDeclaration::Type.overview
           sd.name     = name
-          sd.abstract = Jazzy.markdown.render(abstract)
+          sd.abstract = Markdown.render(abstract)
           sd.children = group
         end
       end
@@ -284,23 +284,6 @@ module Jazzy
       make_default_doc_info(declaration)
     end
 
-    def self.make_paragraphs(doc, key)
-      return nil unless doc[key]
-      doc[key].map do |p|
-        if para = p['Para']
-          Jazzy.markdown.render(para)
-        elsif code = p['Verbatim'] || p['CodeListing']
-          Jazzy.markdown.render("```\n#{code}```\n")
-        else
-          warn "Jazzy could not recognize the `#{p.keys.first}` tag. " \
-               'Please report this by filing an issue at ' \
-               'https://github.com/realm/jazzy/issues along with the comment ' \
-               'including this tag.'
-          Jazzy.markdown.render(p.values.first)
-        end
-      end.join
-    end
-
     def self.parameters(doc, discovered)
       (doc['key.doc.parameters'] || []).map do |p|
         name = p['name']
@@ -330,11 +313,10 @@ module Jazzy
         )
       end
 
-      declaration.abstract =
-        Jazzy.render_declaration(doc['key.doc.comment'] || '')
+      declaration.abstract = Markdown.render(doc['key.doc.comment'] || '')
       declaration.discussion = ''
-      declaration.return = Jazzy.declaration_returns
-      declaration.parameters = parameters(doc, Jazzy.declaration_parameters)
+      declaration.return = Markdown.rendered_returns
+      declaration.parameters = parameters(doc, Markdown.rendered_parameters)
 
       @documented_count += 1
     end


### PR DESCRIPTION
From #476 etc.
This suggests how to display all param/returns markdown like Xcode.  It works by snooping the callout rendering code -- least ugly solution I could find :/  Recommend reading commits separately: first is the actual code, second is a tidy of the ruby interface.

Spec changes show whitespace and apostrophe encoding changes galore, none of which affect browser view; one issue fixed in Siesta (`*and*` previously lost); a few new tests; and an issue I’d like feedback on:

Current jazzy gets param text from sourcekit’s *full_as_xml*.  This is smart: it ascends the Swift inheritance tree to find docs.  This has odd results for example [AnyRealmCollection.index(after:)](https://realm.io/docs/swift/2.6.2/api/Classes/AnyRealmCollection.html#/s:FPs14_IndexableBase5indexFT5afterwx5Index_wxS0_).

This method has no docs [in the source code](https://github.com/realm/realm-cocoa/blob/3df0fb6ec06a0f3c5ca49c88bd51ab5b64f4f0af/RealmSwift/RealmCollection.swift#L530).  It gets its body doc via a sourcekitten bug from the previous declaration, and the param/returns doc from Swift.Collection via *full_as_xml*.

Half a dozen instances of this pattern across Realm + Moya.  So not that common.

With this PR as-is, the inherited param/returns docs go away because they are not in the doc comment.  On balance I feel this is more consistent with jazzy generally not displaying inherited docs.  OTOH those docs are correct.  Please say if you’d prefer these to be retained -- easy change.


(Aside: I wonder vaguely about a change of approach to stop parsing the declaration markdown, leaving that to sourcekit, and instead xslt (etc.) the full_as_xml to html. This would overcome all the markdown parser differences and make use of sourcekit’s ‘track down inherited docs’ feature.  Gives a nice pipeline markdown->xml->html.)