### PR TITLE
Fix an issue when additional xcodebuild arguments are ignored in Objective-C mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ##### Breaking
 
-* None.
+* Fix an issue when additional xcodebuild arguments are ignored in Objective-C mode.
+  [Maksym Grebenets](https://github.com/mgrebenets)
+  [#797](https://github.com/realm/jazzy/issues/797)
 
 ##### Enhancements
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -185,13 +185,10 @@ module Jazzy
     end
 
     def self.objc_arguments_from_options(options)
-      arguments = []
-      if options.xcodebuild_arguments.empty?
-        arguments += ['--objc', options.umbrella_header.to_s, '--', '-x',
-                      'objective-c', '-isysroot',
-                      `xcrun --show-sdk-path --sdk #{options.sdk}`.chomp,
-                      '-I', options.framework_root.to_s]
-      end
+      arguments = ['--objc', options.umbrella_header.to_s, '--', '-x',
+                   'objective-c', '-isysroot',
+                   `xcrun --show-sdk-path --sdk #{options.sdk}`.chomp,
+                   '-I', options.framework_root.to_s]
       # add additional -I arguments for each subdirectory of framework_root
       unless options.framework_root.nil?
         rec_path(Pathname.new(options.framework_root.to_s)).collect do |child|


### PR DESCRIPTION
When running `jazzy` in Objective-C mode like this:

```bash
jazzy --objc \
  --sdk iphonesimulator \
  --umbrella-header Sources/MyFramework.h \
  --module MyFramework \
  --framework-root Sources \
  --no-download-badge \
  --module-version 1.0.0 \
  --output objc-docs
```

`jazzy` adds the following arguments for `sourcekitten` under the hood:

```ruby
["doc",
  "--objc", 
  "/Users/grebenma/Projects/myframework.ios/Sources/MyFramework.h", 
  "--", "-x", "objective-c", 
  "-isysroot", "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator10.2.sdk",
   "-I", "/Users/grebenma/Projects/myframework.ios/Sources"
]
```

But then I want to add `-fmodules` argument for compiler command using `-x` option:

```bash
jazzy --objc \
  --sdk iphonesimulator \
  --umbrella-header Sources/MyFramework.h \
  --module MyFramework \
  --framework-root Sources \
  --no-download-badge \
  --module-version 1.0.0 \
  --output objc-docs \
  -x -fmodules
```

Now `jazzy` will not autogenerate all those build options for `sourcekitten` and the final arguments list will be:

```ruby
["doc", "--", "-fmodules"]
```

This change will make sure that user-specified arguments are _appended_ to automatically generated arguments.

This helps with issues like https://github.com/realm/jazzy/issues/636.

One caveat that now in Objective-C mode users should not use `--` together with `-x` because `--` is already added by `jazzy`.