### PR TITLE
Add -fmodules flag for default objective-c options list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Add `-fmodules` flag for default Objective-C options list.  
+  [Maksym Grebenets](https://github.com/mgrebenets)
+  [#636](https://github.com/realm/jazzy/issues/636)
 
 ## 0.8.1
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -190,7 +190,8 @@ module Jazzy
         arguments += ['--objc', options.umbrella_header.to_s, '--', '-x',
                       'objective-c', '-isysroot',
                       `xcrun --show-sdk-path --sdk #{options.sdk}`.chomp,
-                      '-I', options.framework_root.to_s]
+                      '-I', options.framework_root.to_s,
+                      '-fmodules']
       end
       # add additional -I arguments for each subdirectory of framework_root
       unless options.framework_root.nil?


### PR DESCRIPTION
Another take on #636.
The assumption is that recent projects would have clang modules enabled by this time.

If a project still doesn't use modules, then probably it's build with Xcode 6 or alike and could use `appledoc`...

If user does have a project which doesn't use modules, then probably they should provide all required options via `-x`. Default configuration will work out of the box for most popular configurations.

This is less breaking than #797 