### PR TITLE
Call smartypants differently to avoid ruby 2.2 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix support for Ruby 2.2.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#801](https://github.com/realm/jazzy/issues/801)
 
 ## 0.8.1
 

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -148,7 +148,8 @@ module Jazzy
       def render_param_returns(matches)
         body = matches[:intro].strip + matches[:outro].strip
         body = "<p>#{body}</p>" unless body.start_with?('<p>')
-        Redcarpet::Render::SmartyPants.render(body)
+        # call smartypants for pretty quotes etc.
+        postprocess(body)
       end
     end
 


### PR DESCRIPTION
See #801, some incompatibility between code added in 3c16e0d and ruby 2.2.
Don't understand why the problem happens on 2.2 and not on 2.0/2.4.
This change calls the same routine in a different way - no effect on html.
Works on 2.0/2.2.2/2.4.1.