### PR TITLE
Fix space before parameter abstract in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 * None.
 
 ##### Bug Fixes
-
-* None.
+  
+* Removes a gap before the first character in the abstract of a parameter.  
+  [Nick Brook](https://github.com/nrbrook)
 
 ## 0.8.1
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -313,7 +313,7 @@ module Jazzy
         )
       end
 
-      declaration.abstract = Markdown.render(doc['key.doc.comment'] || '')
+      declaration.abstract = Markdown.render((doc['key.doc.comment'] || '').gsub("\u001F","").strip)
       declaration.discussion = ''
       declaration.return = Markdown.rendered_returns
       declaration.parameters = parameters(doc, Markdown.rendered_parameters)


### PR DESCRIPTION
It seems that the content passed to Markdown contains `codepoint U+001F INFORMATION SEPARATOR ONE` and a newline at the start, causing a newline (and therefore space when displayed) before the first character in the html output. This strips it.