### PR TITLE
Report skipped and included declarations (take 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ##### Breaking
 
-* None.
+* Report numbers of included and skipped declarations in CLI output.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#238](https://github.com/realm/jazzy/issues/238)
 
 ##### Enhancements
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -258,7 +258,8 @@ module Jazzy
       default: false
 
     config_attr :min_acl,
-      command_line: '--min-acl [private | internal | public]',
+      command_line:
+         '--min-acl [private | fileprivate | internal | public | open]',
       description: 'minimum access control level to document',
       default: 'public',
       parse: ->(acl) do

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -143,7 +143,7 @@ module Jazzy
     # @param [Config] options Build options
     # @return [SourceModule] the documented source module
     def self.build_docs_for_sourcekitten_output(sourcekitten_output, options)
-      (docs, coverage, undocumented) = SourceKitten.parse(
+      (docs, stats) = SourceKitten.parse(
         sourcekitten_output,
         options.min_acl,
         options.skip_undocumented,
@@ -152,15 +152,13 @@ module Jazzy
 
       prepare_output_dir(options.output, options.clean)
 
-      puts "#{coverage}\% documentation coverage " \
-        "with #{undocumented.count} undocumented symbol" \
-        "#{undocumented.count == 1 ? '' : 's'}"
+      stats.report
 
       unless options.skip_documentation
-        build_site(docs, coverage, options)
+        build_site(docs, stats.doc_coverage, options)
       end
 
-      write_lint_report(undocumented, options)
+      write_lint_report(stats.undocumented_decls, options)
     end
 
     def self.relative_path_if_inside(path, base_path)

--- a/lib/jazzy/source_declaration/access_control_level.rb
+++ b/lib/jazzy/source_declaration/access_control_level.rb
@@ -89,6 +89,14 @@ module Jazzy
       def <=>(other)
         LEVELS[level] <=> LEVELS[other.level]
       end
+
+      def included_levels
+        LEVELS.select { |_, v| v >= LEVELS[level] }.keys
+      end
+
+      def excluded_levels
+        LEVELS.select { |_, v| v < LEVELS[level] }.keys
+      end
     end
   end
 end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -8,6 +8,7 @@ require 'jazzy/executable'
 require 'jazzy/highlighter'
 require 'jazzy/source_declaration'
 require 'jazzy/source_mark'
+require 'jazzy/stats'
 
 ELIDED_AUTOLINK_TOKEN = '36f8f5912051ae747ef441d6511ca4cb'.freeze
 
@@ -46,8 +47,6 @@ end
 module Jazzy
   # This module interacts with the sourcekitten command-line executable
   module SourceKitten
-    @documented_count = 0
-    @undocumented_decls = []
     @default_abstract = Markdown.render('Undocumented').freeze
 
     # Group root-level docs by custom categories (if any) and type
@@ -263,7 +262,8 @@ module Jazzy
         end
       end
 
-      SourceDeclaration::AccessControlLevel.from_doc(doc) >= @min_acl
+      acl_ok = SourceDeclaration::AccessControlLevel.from_doc(doc) >= @min_acl
+      acl_ok.tap { @stats.add_acl_skipped unless acl_ok }
     end
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
@@ -278,7 +278,7 @@ module Jazzy
       filepath = doc['key.filepath']
       objc = Config.instance.objc_mode
       if objc || should_mark_undocumented(doc['key.kind'], filepath)
-        @undocumented_decls << declaration
+        @stats.add_undocumented(declaration)
       end
       return nil if !documented_child?(doc) && @skip_undocumented
       make_default_doc_info(declaration)
@@ -318,7 +318,7 @@ module Jazzy
       declaration.return = Markdown.rendered_returns
       declaration.parameters = parameters(doc, Markdown.rendered_parameters)
 
-      @documented_count += 1
+      @stats.add_documented
     end
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
@@ -388,12 +388,6 @@ module Jazzy
     # rubocop:enable Metrics/PerceivedComplexity
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/MethodLength
-
-    def self.doc_coverage
-      return 0 if @documented_count == 0 && @undocumented_decls.count == 0
-      (100 * @documented_count) /
-        (@undocumented_decls.count + @documented_count)
-    end
 
     # Merges multiple extensions of the same entity into a single document.
     #
@@ -614,6 +608,7 @@ module Jazzy
     def self.parse(sourcekitten_output, min_acl, skip_undocumented, inject_docs)
       @min_acl = min_acl
       @skip_undocumented = skip_undocumented
+      @stats = Stats.new
       sourcekitten_json = filter_excluded_files(JSON.parse(sourcekitten_output))
       docs = make_source_declarations(sourcekitten_json).concat inject_docs
       docs = deduplicate_declarations(docs)
@@ -628,7 +623,7 @@ module Jazzy
       docs = group_docs(docs)
       make_doc_urls(docs)
       autolink(docs, ungrouped_docs)
-      [docs, doc_coverage, @undocumented_decls]
+      [docs, @stats]
     end
   end
 end

--- a/lib/jazzy/stats.rb
+++ b/lib/jazzy/stats.rb
@@ -1,0 +1,74 @@
+module Jazzy
+  # Collect + report metadata about a processed module
+  class Stats
+    include Config::Mixin
+
+    attr_reader :documented, :acl_skipped
+    attr_reader :undocumented_decls
+
+    def add_documented
+      @documented += 1
+    end
+
+    def add_acl_skipped
+      @acl_skipped += 1
+    end
+
+    def add_undocumented(decl)
+      @undocumented_decls << decl
+    end
+
+    def acl_included
+      documented + undocumented_decls.count
+    end
+
+    def undocumented
+      undocumented_decls.count
+    end
+
+    def initialize
+      @documented = @acl_skipped = 0
+      @undocumented_decls = []
+    end
+
+    def report
+      puts "#{doc_coverage}\% documentation coverage " \
+        "with #{undocumented} undocumented " \
+        "#{symbol_or_symbols(undocumented)}"
+
+      if acl_included > 0
+        swift_acls = comma_list(config.min_acl.included_levels)
+        puts "included #{acl_included} " +
+             (config.objc_mode ? '' : "#{swift_acls} ") +
+             symbol_or_symbols(acl_included)
+      end
+
+      if !config.objc_mode && acl_skipped > 0
+        puts "skipped #{acl_skipped} " \
+          "#{comma_list(config.min_acl.excluded_levels)} " \
+          "#{symbol_or_symbols(acl_skipped)} " \
+          '(use `--min_acl` to see)'
+      end
+    end
+
+    def doc_coverage
+      return 0 if acl_included == 0
+      (100 * documented) / acl_included
+    end
+
+    private
+
+    def comma_list(items)
+      case items.count
+      when 0 then ''
+      when 1 then items[0]
+      when 2 then "#{items[0]} or #{items[1]}"
+      else "#{items[0..-2].join(', ')}, or #{items[-1]}"
+      end
+    end
+
+    def symbol_or_symbols(count)
+      count == 1 ? 'symbol' : 'symbols'
+    end
+  end
+end


### PR DESCRIPTION
This adds a report to stdout about the number of declarations included/skipped in the docs, pretty much per #238, eg.

    included 964 public or open symbols
    skipped 189 private, fileprivate, or internal symbols (use `--min_acl` to see)

New users are still having acl problems with their first use of jazzy, maybe this will help some.

Added a specs change to match for CI -- will redo when Xcode 83 stuff is in.  No rush, already two years since this issue was opened...