### PR TITLE
Display doc comments for all swift extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix missing doc comments on some extensions.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#454](https://github.com/realm/jazzy/issues/454)
 
 ## 0.8.2
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -281,8 +281,15 @@ module Jazzy
       if objc || should_mark_undocumented(doc['key.kind'], filepath)
         @stats.add_undocumented(declaration)
       end
+
       return nil if !documented_child?(doc) && @skip_undocumented
+
       make_default_doc_info(declaration)
+      if doc.key?('key.doc.comment')
+        # eg. swift extension of a type from a non-swift module
+        declaration.abstract = Markdown.render(doc['key.doc.comment'])
+      end
+      declaration
     end
 
     def self.parameters(doc, discovered)

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -47,7 +47,7 @@ end
 module Jazzy
   # This module interacts with the sourcekitten command-line executable
   module SourceKitten
-    @default_abstract = Markdown.render('Undocumented').freeze
+    @undocumented_abstract = Markdown.render('Undocumented').freeze
 
     # Group root-level docs by custom categories (if any) and type
     def self.group_docs(docs)
@@ -222,7 +222,7 @@ module Jazzy
       # @todo: Fix these
       declaration.line = nil
       declaration.column = nil
-      declaration.abstract = @default_abstract
+      declaration.abstract = ''
       declaration.parameters = []
       declaration.children = []
     end
@@ -276,19 +276,19 @@ module Jazzy
     end
 
     def self.process_undocumented_token(doc, declaration)
+      make_default_doc_info(declaration)
+
       filepath = doc['key.filepath']
       objc = Config.instance.objc_mode
       if objc || should_mark_undocumented(doc['key.kind'], filepath)
         @stats.add_undocumented(declaration)
+        declaration.abstract = @undocumented_abstract
+      else
+        comment = doc['key.doc.comment']
+        declaration.abstract = Markdown.render(comment) if comment
       end
 
       return nil if !documented_child?(doc) && @skip_undocumented
-
-      make_default_doc_info(declaration)
-      if doc.key?('key.doc.comment')
-        # eg. swift extension of a type from a non-swift module
-        declaration.abstract = Markdown.render(doc['key.doc.comment'])
-      end
       declaration
     end
 


### PR DESCRIPTION
See #454, #620.
Now sourcekitten is passing on doc comments of extensions, this PR displays them.  The corner case where this wasn't working is Swift extensions of Objective C classes like `Foundation.NSDate`: in this case sourcekit does not provide the full_as_xml field.

Specs changes show one fix in Siesta demonstrating exactly this, and another 'fix' in realm-swift where a previously missed doc comment is now displayed --- [the declaration](https://realm.io/docs/swift/2.7.0/api/Classes/Object.html#/) shouldn't be present at all, I think, but that's another story + not a regression here...

edit with latest push: also propose dropping the 'undocumented' label on swift extensions of objc classes *without* doc comments, for consistency with other extensions + because they do not contribute to undocumented%.  Spec changes reflect that.