### PR TITLE
Make --skip-undocumented less aggressive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@
   [#824](https://github.com/realm/jazzy/issues/824)
 
 * Stop --skip-undocumented from skipping documented items nested
-  inside undocumented items.  
+  inside extensions of types from other modules.  
   [John Fairhurst](https://github.com/johnfairh)
-  [#732](https://github.com/realm/jazzy/issues/732)
+  [#502](https://github.com/realm/jazzy/issues/502)
 
 ## 0.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
   [JP Simard](https://github.com/jpsim)
   [#824](https://github.com/realm/jazzy/issues/824)
 
+* Stop --skip-undocumented from skipping documented items nested
+  inside undocumented items.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#732](https://github.com/realm/jazzy/issues/732)
+
 ## 0.8.2
 
 ##### Breaking

--- a/Rakefile
+++ b/Rakefile
@@ -55,23 +55,14 @@ begin
     # Remove files not used for the comparison
     # To keep the git diff clean
     files_glob = 'spec/integration_specs/*/after/{*,.*}'
-    exec_output_glob = 'spec/integration_specs/*/after/execution_output.txt'
     files_to_delete = FileList[files_glob]
       .exclude('**/.', '**/..')
       .exclude('spec/integration_specs/*/after/*docs',
-               exec_output_glob)
+               'spec/integration_specs/*/after/execution_output.txt')
       .include('**/*.dsidx')
       .include('**/*.tgz')
     files_to_delete.each do |file_to_delete|
       sh "rm -rf '#{file_to_delete}'"
-    end
-
-    # Remove version numbers from CocoaPods dependencies
-    # to make specs resilient against dependecy updates.
-    FileList[exec_output_glob].each do |file|
-      sanitized = File.open(file, &:read)
-                      .gsub(/(Installing \w+ )\((.*)\)/, '\1(X.Y.Z)')
-      File.write(file, sanitized)
     end
 
     puts

--- a/Rakefile
+++ b/Rakefile
@@ -55,14 +55,23 @@ begin
     # Remove files not used for the comparison
     # To keep the git diff clean
     files_glob = 'spec/integration_specs/*/after/{*,.*}'
+    exec_output_glob = 'spec/integration_specs/*/after/execution_output.txt'
     files_to_delete = FileList[files_glob]
       .exclude('**/.', '**/..')
       .exclude('spec/integration_specs/*/after/*docs',
-               'spec/integration_specs/*/after/execution_output.txt')
+               exec_output_glob)
       .include('**/*.dsidx')
       .include('**/*.tgz')
     files_to_delete.each do |file_to_delete|
       sh "rm -rf '#{file_to_delete}'"
+    end
+
+    # Remove version numbers from CocoaPods dependencies
+    # to make specs resilient against dependecy updates.
+    FileList[exec_output_glob].each do |file|
+      sanitized = File.open(file, &:read)
+                      .gsub(/(Installing \w+ )\((.*)\)/, '\1(X.Y.Z)')
+      File.write(file, sanitized)
     end
 
     puts

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -229,7 +229,10 @@ module Jazzy
 
     def self.documented_child?(doc)
       return false unless doc['key.substructure']
-      doc['key.substructure'].any? { |child| documented_child?(child) }
+      doc['key.substructure'].any? do |child|
+        should_document?(child) &&
+          (can_document?(child) || documented_child?(child))
+      end
     end
 
     def self.availability_attribute?(doc)
@@ -302,12 +305,16 @@ module Jazzy
       end
     end
 
+    def self.can_document?(doc)
+      doc.key?('key.doc.full_as_xml')
+    end
+
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
     def self.make_doc_info(doc, declaration)
       return unless should_document?(doc)
 
-      unless doc['key.doc.full_as_xml']
+      unless can_document?(doc)
         return process_undocumented_token(doc, declaration)
       end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -227,14 +227,6 @@ module Jazzy
       declaration.children = []
     end
 
-    def self.documented_child?(doc)
-      return false unless doc['key.substructure']
-      doc['key.substructure'].any? do |child|
-        should_document?(child) &&
-          (can_document?(child) || documented_child?(child))
-      end
-    end
-
     def self.availability_attribute?(doc)
       return false unless doc['key.attributes']
       !doc['key.attributes'].select do |attribute|
@@ -285,13 +277,13 @@ module Jazzy
       objc = Config.instance.objc_mode
       if objc || should_mark_undocumented(doc['key.kind'], filepath)
         @stats.add_undocumented(declaration)
+        return nil if @skip_undocumented
         declaration.abstract = @undocumented_abstract
       else
         comment = doc['key.doc.comment']
         declaration.abstract = Markdown.render(comment) if comment
       end
 
-      return nil if !documented_child?(doc) && @skip_undocumented
       declaration
     end
 
@@ -305,16 +297,12 @@ module Jazzy
       end
     end
 
-    def self.can_document?(doc)
-      doc.key?('key.doc.full_as_xml')
-    end
-
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
     def self.make_doc_info(doc, declaration)
       return unless should_document?(doc)
 
-      unless can_document?(doc)
+      unless doc['key.doc.full_as_xml']
         return process_undocumented_token(doc, declaration)
       end
 
@@ -396,6 +384,7 @@ module Jazzy
 
         next unless make_doc_info(doc, declaration)
         make_substructure(doc, declaration)
+        next if declaration.type.extension? && declaration.children.empty?
         declarations << declaration
       end
       declarations

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -104,6 +104,9 @@ describe_cli 'jazzy' do
     s.default_args = []
     s.replace_path ROOT.to_s, 'ROOT'
     s.replace_pattern /^[\d\s:.-]+ ruby\[\d+:\d+\] warning:.*$[\n]?/, ''
+    # Remove version numbers from CocoaPods dependencies
+    # to make specs resilient against dependecy updates.
+    s.replace_pattern /(Installing \w+ )\((.*)\)/, '\1(X.Y.Z)'
   end
 
   require 'shellwords'


### PR DESCRIPTION
Continuing @freak4pc’s investigation from #508, also issue #732.
This PR fixes `--skip-undocumented` so that an undocumented declaration is not skipped if any of its subtree is documented.

Spec changes show a new extension to `URLRequest` being discovered in AlamoFire (which sets this option) -- affects left nav so all files show changes.
