### PR TITLE
Add Test Fixtures for Treatment of Undocumented Symbols

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -212,5 +212,13 @@ describe_cli 'jazzy' do
     describe 'Creates docs for Swift project with a variety of contents' do
       behaves_like cli_spec 'misc_jazzy_features'
     end
+    describe 'Checks evolution of behaviour involving ' \
+             '--skip-undocumented and undocumented.json' \
+             'against project goals.' do
+      behaves_like cli_spec 'behaviours_for_undocumented',
+                            '--xcodebuild-arguments ' \
+                            '-target,Behaviours ' \
+                            '--skip-undocumented'
+    end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -212,12 +212,12 @@ describe_cli 'jazzy' do
     describe 'Creates docs for Swift project with a variety of contents' do
       behaves_like cli_spec 'misc_jazzy_features'
     end
-    describe 'Checks evolution of behaviour involving ' \
+    describe 'Checks evolution of behavior involving ' \
              '--skip-undocumented and undocumented.json' \
              'against project goals.' do
-      behaves_like cli_spec 'behaviours_for_undocumented',
+      behaves_like cli_spec 'behaviors_for_undocumented',
                             '--xcodebuild-arguments ' \
-                            '-target,Behaviours ' \
+                            '-target,Behaviors ' \
                             '--skip-undocumented'
     end
   end


### PR DESCRIPTION
This enables the tests in realm/jazzy-integration-specs#33. A detailed description can be found there.

This does not affect Jazzy itself in any way.