### PR TITLE
Merge nested type extensions into original types

### DIFF
--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -39,7 +39,7 @@ module Jazzy
           # FIXME: include arbitrarily nested extensible types
           [{ name: child.name, url: child.url }] +
             Array(child.children.select do |sub_child|
-              sub_child.type.swift_extensible?
+              sub_child.type.swift_extensible? || sub_child.type.extension?
             end).map do |sub_child|
               { name: "– #{sub_child.name}", url: sub_child.url }
             end


### PR DESCRIPTION
This tidies up extensions of nested types so that the extensions are merged into the original
type, just like extensions of non-nested types.

Spec changes in alamofire + realm-swift to reflect this, left-nav changes so all files change :/
Added some more tests for this kind of thing to misc_jazzy_features.

I decided to leave the changelog alone 'cos this is more of #333.