### PR TITLE
Fixes to autolinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
   [JP Simard](https://github.com/jpsim)
   [#860](https://github.com/realm/jazzy/issues/860)
 
+* Autolink from parameter documentation and from external markdown documents
+  including README.  Autolink to symbols containing & < >.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#715](https://github.com/realm/jazzy/issues/715)
+  [#789](https://github.com/realm/jazzy/issues/789)
+  [#805](https://github.com/realm/jazzy/issues/805)
+
 ## 0.8.3
 
 ##### Breaking

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -208,6 +208,11 @@ module Jazzy
       end
     end
 
+    def self.render(doc_model, markdown)
+      html = Markdown.render(markdown)
+      SourceKitten.autolink_document(html, doc_model)
+    end
+
     # Build Mustache document from a markdown source file
     # @param [Config] options Build options
     # @param [Hash] doc_model Parsed doc. @see SourceKitten.parse
@@ -218,7 +223,7 @@ module Jazzy
       doc = Doc.new # Mustache model instance
       name = doc_model.name == 'index' ? source_module.name : doc_model.name
       doc[:name] = name
-      doc[:overview] = Markdown.render(doc_model.content(source_module))
+      doc[:overview] = render(doc_model, doc_model.content(source_module))
       doc[:custom_head] = Config.instance.custom_head
       doc[:disable_search] = Config.instance.disable_search
       doc[:doc_coverage] = source_module.doc_coverage unless
@@ -230,7 +235,7 @@ module Jazzy
       doc[:dash_url] = source_module.dash_url
       doc[:path_to_root] = path_to_root
       doc[:hide_name] = true
-      doc.render
+      doc.render.gsub(ELIDED_AUTOLINK_TOKEN, path_to_root)
     end
 
     # Returns the appropriate color for the provided percentage,
@@ -365,7 +370,7 @@ module Jazzy
       overview = (doc_model.abstract || '') + (doc_model.discussion || '')
       alternative_abstract = doc_model.alternative_abstract
       if alternative_abstract
-        overview = Markdown.render(alternative_abstract) + overview
+        overview = render(doc_model, alternative_abstract) + overview
       end
 
       doc = Doc.new # Mustache model instance

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'pathname'
 require 'shellwords'
 require 'xcinvoke'
+require 'CGI'
 
 require 'jazzy/config'
 require 'jazzy/executable'
@@ -27,7 +28,7 @@ class String
     gsub(autolink_regex(middle_regex, after_highlight)) do
       original = Regexp.last_match(0)
       start_tag, raw_name, end_tag = Regexp.last_match.captures
-      link_target = yield(raw_name)
+      link_target = yield(CGI.unescape_html(raw_name))
 
       if link_target &&
          !link_target.type.extension? &&
@@ -540,7 +541,7 @@ module Jazzy
       return nil unless name_part
       wildcard_expansion = Regexp.escape(name_part)
                                  .gsub('\.\.\.', '[^)]*')
-                                 .gsub(/&lt;.*&gt;/, '')
+                                 .gsub(/<.*>/, '')
       whole_name_pat = /\A#{wildcard_expansion}\Z/
       docs.find do |doc|
         whole_name_pat =~ doc.name

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -603,6 +603,7 @@ module Jazzy
     end
 
     def self.autolink(docs, root_decls)
+      @autolink_root_decls = root_decls
       docs.each do |doc|
         doc.children = autolink(doc.children, root_decls)
 
@@ -625,6 +626,11 @@ module Jazzy
           )
         end
       end
+    end
+
+    # For autolinking external markdown documents
+    def self.autolink_document(html, doc)
+      autolink_text(html, doc, @autolink_root_decls || [])
     end
 
     def self.reject_objc_types(docs)

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -294,7 +294,7 @@ module Jazzy
           name: name,
           discussion: discovered[name],
         }
-      end
+      end.reject { |param| param[:discussion].nil? }
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity
@@ -607,6 +607,10 @@ module Jazzy
 
         doc.return = autolink_text(doc.return, doc, root_decls) if doc.return
         doc.abstract = autolink_text(doc.abstract, doc, root_decls)
+        (doc.parameters || []).each do |param|
+          param[:discussion] =
+            autolink_text(param[:discussion], doc, root_decls)
+        end
 
         if doc.declaration
           doc.declaration = autolink_text(


### PR DESCRIPTION
Autolink to symbols from parameter documentation (#789) and from external markdown files, readme / documentation / custom abstract (#715).
Autolink correctly to symbols containing & < > (#805).

Fix something I broke earlier that caused undocumented parameters to appear in the parameter tables -- found while autolinking parameters.

Specs changes:
* RealmObjC - add linking from parameter descriptions
* Moya - delete empty parameters
* Alamofire - add linking from parameters and README.md
* RealmSwift - delete empty parameters; add linking from parameters
* Sierra - add linking from parameters
* MiscJazzyFeatures - add new tests