### PR TITLE
Align 'jazzy' terminology with Apple usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Align jazzy terminology with Apple usage.  
+  [Xiaodi Wu](https://github.com/xwu)
 
 ##### Bug Fixes
 

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -137,11 +137,11 @@ module Jazzy
           dash: 'Constant',
         }.freeze,
         'sourcekitten.source.lang.objc.decl.enum' => {
-          jazzy: 'Enum',
+          jazzy: 'Enumeration',
           dash: 'Enum',
         }.freeze,
         'sourcekitten.source.lang.objc.decl.enumcase' => {
-          jazzy: 'Enum Case',
+          jazzy: 'Enumeration Case',
           dash: 'Case',
         }.freeze,
         'sourcekitten.source.lang.objc.decl.initializer' => {
@@ -177,7 +177,7 @@ module Jazzy
           dash: 'Function',
         }.freeze,
         'sourcekitten.source.lang.objc.decl.struct' => {
-          jazzy: 'Struct',
+          jazzy: 'Structure',
           dash: 'Struct',
         }.freeze,
         'sourcekitten.source.lang.objc.decl.field' => {
@@ -195,27 +195,27 @@ module Jazzy
 
         # Swift
         'source.lang.swift.decl.function.accessor.address' => {
-          jazzy: 'Address Accessor',
+          jazzy: 'Addressor',
           dash: 'Function',
         }.freeze,
         'source.lang.swift.decl.function.accessor.didset' => {
-          jazzy: 'DidSet Accessor',
+          jazzy: 'didSet Observer',
           dash: 'Function',
         }.freeze,
         'source.lang.swift.decl.function.accessor.getter' => {
-          jazzy: 'Getter Accessor',
+          jazzy: 'Getter',
           dash: 'Function',
         }.freeze,
         'source.lang.swift.decl.function.accessor.mutableaddress' => {
-          jazzy: 'Mutable Address Accessor',
+          jazzy: 'Mutable Addressor',
           dash: 'Function',
         }.freeze,
         'source.lang.swift.decl.function.accessor.setter' => {
-          jazzy: 'Setter Accessor',
+          jazzy: 'Setter',
           dash: 'Function',
         }.freeze,
         'source.lang.swift.decl.function.accessor.willset' => {
-          jazzy: 'WillSet Accessor',
+          jazzy: 'willSet Observer',
           dash: 'Function',
         }.freeze,
         'source.lang.swift.decl.function.operator' => {
@@ -247,11 +247,11 @@ module Jazzy
           dash: 'Class',
         }.freeze,
         'source.lang.swift.decl.function.constructor' => {
-          jazzy: 'Constructor',
+          jazzy: 'Initializer',
           dash: 'Constructor',
         }.freeze,
         'source.lang.swift.decl.function.destructor' => {
-          jazzy: 'Destructor',
+          jazzy: 'Deinitializer',
           dash: 'Method',
         }.freeze,
         'source.lang.swift.decl.var.global' => {
@@ -259,15 +259,15 @@ module Jazzy
           dash: 'Global',
         }.freeze,
         'source.lang.swift.decl.enumcase' => {
-          jazzy: 'Enum Case',
+          jazzy: 'Enumeration Case',
           dash: 'Case',
         }.freeze,
         'source.lang.swift.decl.enumelement' => {
-          jazzy: 'Enum Element',
+          jazzy: 'Enumeration Element',
           dash: 'Element',
         }.freeze,
         'source.lang.swift.decl.enum' => {
-          jazzy: 'Enum',
+          jazzy: 'Enumeration',
           dash: 'Enum',
         }.freeze,
         'source.lang.swift.decl.extension' => {
@@ -279,7 +279,7 @@ module Jazzy
           dash: 'Extension',
         }.freeze,
         'source.lang.swift.decl.extension.enum' => {
-          jazzy: 'Enum Extension',
+          jazzy: 'Enumeration Extension',
           dash: 'Extension',
         }.freeze,
         'source.lang.swift.decl.extension.protocol' => {
@@ -287,7 +287,7 @@ module Jazzy
           dash: 'Extension',
         }.freeze,
         'source.lang.swift.decl.extension.struct' => {
-          jazzy: 'Struct Extension',
+          jazzy: 'Structure Extension',
           dash: 'Extension',
         }.freeze,
         'source.lang.swift.decl.function.free' => {
@@ -323,7 +323,7 @@ module Jazzy
           dash: 'Variable',
         }.freeze,
         'source.lang.swift.decl.struct' => {
-          jazzy: 'Struct',
+          jazzy: 'Structure',
           dash: 'Struct',
         }.freeze,
         'source.lang.swift.decl.function.subscript' => {
@@ -331,7 +331,7 @@ module Jazzy
           dash: 'Method',
         }.freeze,
         'source.lang.swift.decl.typealias' => {
-          jazzy: 'Typealias',
+          jazzy: 'Type Alias',
           dash: 'Alias',
         }.freeze,
         'source.lang.swift.decl.generic_type_param' => {

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -185,7 +185,7 @@ module Jazzy
           dash: 'Field',
         }.freeze,
         'sourcekitten.source.lang.objc.decl.ivar' => {
-          jazzy: 'Ivar',
+          jazzy: 'Instance Variable',
           dash: 'Ivar',
         }.freeze,
         'sourcekitten.source.lang.objc.module.import' => {


### PR DESCRIPTION
When comparing documentation generated by Jazzy with those on Apple's developer site, _The Swift Programming Language_, and documentation in the Swift Project GitHub repository, some of the terminology is written out differently in public-facing contexts. Since a consistent usage can be helpful for users, this proposed change aligns Jazzy with those canonical sources.

Hopefully, this is considered a helpful modification and not duplicative of any previous proposed changes :)

> Should this be considered a productive change, I'll need guidance as to how to update the integration specs so that CI will pass.