### PR TITLE
Rename category files to restore URL naming

### DIFF
--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -46,6 +46,7 @@ module Jazzy
         end
         {
           section: doc.name,
+          url: doc.url,
           children: children,
         }
       end

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -76,6 +76,7 @@ module Jazzy
     attr_accessor :start_line
     attr_accessor :end_line
     attr_accessor :nav_order
+    attr_accessor :url_name
 
     def alternative_abstract
       if file = alternative_abstract_file
@@ -85,7 +86,8 @@ module Jazzy
 
     def alternative_abstract_file
       abstract_glob.select do |f|
-        File.basename(f).split('.').first == name
+        # allow Structs.md or Structures.md
+        [name, url_name].include?(File.basename(f).split('.').first)
       end.first
     end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -83,17 +83,19 @@ module Jazzy
           children,
           type_category_prefix + type.plural_name,
           "The following #{type.plural_name.downcase} are available globally.",
+          type_category_prefix + type.plural_url_name,
         )
       end
       [group.compact, docs]
     end
 
-    def self.make_group(group, name, abstract)
+    def self.make_group(group, name, abstract, url_name = nil)
       group.reject! { |doc| doc.name.empty? }
       unless group.empty?
         SourceDeclaration.new.tap do |sd|
           sd.type     = SourceDeclaration::Type.overview
           sd.name     = name
+          sd.url_name = url_name
           sd.abstract = Markdown.render(abstract)
           sd.children = group
         end
@@ -101,7 +103,7 @@ module Jazzy
     end
 
     def self.sanitize_filename(doc)
-      unsafe_filename = doc.name
+      unsafe_filename = doc.url_name || doc.name
       sanitzation_enabled = Config.instance.use_safe_filenames
       if sanitzation_enabled && !doc.type.name_controlled_manually?
         return CGI.escape(unsafe_filename).gsub('_', '%5F').tr('%', '_')

--- a/lib/jazzy/themes/apple/templates/nav.mustache
+++ b/lib/jazzy/themes/apple/templates/nav.mustache
@@ -2,7 +2,7 @@
   <ul class="nav-groups">
     {{#structure}}
     <li class="nav-group-name">
-      <a href="{{path_to_root}}{{section}}.html">{{section}}</a>
+      <a href="{{path_to_root}}{{url}}">{{section}}</a>
       <ul class="nav-group-tasks">
         {{#children}}
         <li class="nav-group-task">

--- a/lib/jazzy/themes/fullwidth/templates/nav.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/nav.mustache
@@ -2,7 +2,7 @@
   <ul class="nav-groups">
     {{#structure}}
     <li class="nav-group-name">
-      <a class="nav-group-name-link" href="{{path_to_root}}{{section}}.html">{{section}}</a>
+      <a class="nav-group-name-link" href="{{path_to_root}}{{url}}">{{section}}</a>
       <ul class="nav-group-tasks">
         {{#children}}
         <li class="nav-group-task">


### PR DESCRIPTION
This PR restores all URLs to be the same as before #884 while keeping the new terminology in text.
[Spec diffs from before any terminology changes to this PR.](https://github.com/realm/jazzy-integration-specs/compare/4c740e7a5cefd59cb775f8fbe995b99d7c9d7f38...jf-fix-all-urls)

I realized the current code in master has broken custom abstract markdown for files like Struct[ure]s.md, one more reason to do this.

I had to change the moustache template though which hard-coded filename == nav text.  Does this mean this is a still a breaking change because users with custom themes will need to refresh that file?