### PR TITLE
Fix declarations for undocumented symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#894](https://github.com/realm/jazzy/issues/894)
 
+* Always display correct declaration for undocumented symbols.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#864](https://github.com/realm/jazzy/issues/864)
+
 ## 0.8.4
 
 ##### Breaking

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -307,7 +307,7 @@ module Jazzy
     def self.render_item(item, source_module)
       # Combine abstract and discussion into abstract
       abstract = (item.abstract || '') + (item.discussion || '')
-      item_render = {
+      {
         name:                       item.name,
         abstract:                   abstract,
         declaration:                item.declaration,
@@ -323,7 +323,6 @@ module Jazzy
         start_line:                 item.start_line,
         end_line:                   item.end_line,
       }
-      item_render.reject { |_, v| v.nil? }
     end
 
     def self.make_task(mark, uid, items)

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -306,10 +306,6 @@ module Jazzy
     def self.make_doc_info(doc, declaration)
       return unless should_document?(doc)
 
-      unless doc['key.doc.full_as_xml']
-        return process_undocumented_token(doc, declaration)
-      end
-
       declaration.declaration = Highlighter.highlight(
         doc['key.parsed_declaration'] || doc['key.doc.declaration'],
         Config.instance.objc_mode ? 'objc' : 'swift',
@@ -318,6 +314,10 @@ module Jazzy
         declaration.other_language_declaration = Highlighter.highlight(
           doc['key.swift_declaration'], 'swift'
         )
+      end
+
+      unless doc['key.doc.full_as_xml']
+        return process_undocumented_token(doc, declaration)
       end
 
       declaration.abstract = Markdown.render(doc['key.doc.comment'] || '')


### PR DESCRIPTION
First step towards improved Swift declarations.  This PR fixes/adds declarations for undocumented symbols: currently these symbols either get no declaration or (wrongly) get a copy of their parent's declaration (#864).

I think it is useful to include the declarations for undocumented symbols in the docs: helps users understand the API; from the spec projects is not uncommon to leave some members uncommented.

Specs changes, pretty ugly in the (common) 'wrong parent decl -> correct decl' case :/

misc_jazzy_objc_features
* Add decls for undocumented symbols

document_moya_podspec
* CancellableToken, CredentialsPlugin, Endpoint, MoyaProvider, NetworkActivityPlugin, NetworkLoggerPlugin, Response, AuthorizationType, MultiTarget, NetworkActivityChangeType, Method, SignalProducerProtocol, Cancellable, TargetType, FormDataProvider - fix incorrect member decls
* MoyaError, convertResponseToResult(_:request:data:error:), MoyaProviderType, ProgressResponse - add decl for undocumented symbols

document_realm_swift
* Object - remove incorrect declaration from #ifdef’d out version of `className`.

document_siesta
* RequestError.Cause.* -- fix incorrect member decls

misc_jazzy_features
* Various, add decls for undocumented symbols & fix incorrect member decls.
* Add specific new test for #ifdef case.
* Minor change to how unwanted generic type params are documented - still wrong though.
