### PR TITLE
Improve Swift declarations using SourceKit's version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
   [Nick Fox](https://github.com/nicholasffox)
   [#949](https://github.com/realm/jazzy/issues/949)
 
+* Improve Swift declarations to look more like the Xcode Quick Help version,
+  for example including { get set }, and include all attributes.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#768](https://github.com/realm/jazzy/issues/768)
+  [#591](https://github.com/realm/jazzy/issues/591)
+
 ##### Bug Fixes
 
 * Preserve `MARK` comment headings associated with extensions and enum cases.  

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -49,6 +49,14 @@ module Jazzy
       namespace_path.map(&:name).join('.')
     end
 
+    # :name doesn't include any generic type params.
+    # This regexp matches any generic type params in parent names.
+    def fully_qualified_name_regexp
+      Regexp.new(namespace_path.map(&:name)
+                               .map { |n| Regexp.escape(n) }
+                               .join('(?:<.*?>)?\.'))
+    end
+
     # If this declaration is an objc category, returns an array with the name
     # of the extended objc class and the category name itself, i.e.
     # ["NSString", "MyMethods"], nil otherwise.


### PR DESCRIPTION
_Still working through specs and tweaking things, appreciate feedback about any of this especially around how `@attribute`s are handled._

This changes Swift declarations to use the compiler’s round-tripped version instead of the raw parsed source code in many cases.  Improvements:
* Show { get } / { get set } for properties in protocols, for subscripts, and for computed properties
* If code says `var fs = “Fred”` then show decl `var fs: String`
* Don’t show unwanted code fragments that confused the sourcekitten parser (eg. #768)
* Show all declaration attributes (eg. `@discardable, @objc, @available`) 
* Standardize formatting (eg. whitespace)

Still prefer the parsed declaration when it is better:
* Functions with default parameters.  Values not available from compiler, SR-2608, perhaps fixed in Swift 5.
* Declarations arranged over multiple lines - presume the user has formatted these nicely so keep them.  Should fix to be adaptive in Jazzy html/js some day.
* A ?bug to do with `@escaping / @autoclosure` - SR 6321, try + fix for Swift 4.1.

Re. decl attributes, I’ve chosen to stack these each on their own line, to avoid very long lines. I think they’re all useful in docs --- API users may legitimately want to know these?  Eg:

![screen shot 2017-10-27 at 14 45 55](https://user-images.githubusercontent.com/26768470/32488101-708c4108-c3a3-11e7-892c-238f72e3ba67.png)

![screen shot 2017-10-27 at 15 02 36](https://user-images.githubusercontent.com/26768470/32488109-776aa47e-c3a3-11e7-90be-8f44cbc2df8c.png)

![screen shot 2017-10-27 at 18 05 11](https://user-images.githubusercontent.com/26768470/32488130-8d9b9b0e-c3a3-11e7-88d3-dba56c34cff9.png)
[this last fabricated of course but you get the idea...]

Jazzy should handle `@available` in a more visual way but for now I think it’s an improvement to pass through what the author wrote?  The highlighting is a bit ugly; there’s a rouge PR to improve it.

Notes on spec changes in the specs PR.
