### PR TITLE
update integration specs for Xcode 9.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 8.3.2 installed to build the integration specs.
+You must have Xcode 9.1 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "9.0"
+    version: "9.1"
 
 checkout:
   post:

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -208,8 +208,8 @@ describe_cli 'jazzy' do
       behaves_like cli_spec 'document_siesta',
                             # Siesta already has Docs/
                             '--output api-docs',
-                            # Use Swift 4 rather than the specified 3.0.2
-                            '--swift-version=4'
+                            # Use Swift 4.0.2 rather than the specified 3.0.2
+                            '--swift-version=4.0.2'
     end
 
     describe 'Creates docs for Swift project with a variety of contents' do


### PR DESCRIPTION
Update specs for Xcode 9.1 / Swift 4.0.2.
NFC to jazzy, no significant changes to specs.