### PR TITLE
Making the "Undocumented" text for functions that are not documented. configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 ##### Enhancements
 
-* None.
+* Added a config option (--undocumented-text) to set the default text for
+  undocumented code.
+  [Akhil Batra](https://github.com/akhillies)
+  [#913](https://github.com/realm/jazzy/issues/913)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   [Akhil Batra](https://github.com/akhillies)
   [#913](https://github.com/realm/jazzy/issues/913)
 
+
 ##### Bug Fixes
 
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ##### Enhancements
 
-* Added a config option (`--undocumented-text UNDOCUMENTED_TEXT`) to set the default text for
-  undocumented symbols.
+* Added a config option (`--undocumented-text UNDOCUMENTED_TEXT`) to set the
+  default text for undocumented symbols.  
   [Akhil Batra](https://github.com/akhillies)
   [#913](https://github.com/realm/jazzy/issues/913)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ##### Enhancements
 
-* Added a config option (--undocumented-text) to set the default text for
-  undocumented code.
+* Added a config option (`--undocumented-text UNDOCUMENTED_TEXT`) to set the default text for
+  undocumented symbols.
   [Akhil Batra](https://github.com/akhillies)
   [#913](https://github.com/realm/jazzy/issues/913)
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -328,7 +328,13 @@ module Jazzy
         raise '--assets-directory is deprecated: use --theme instead.'
       end
 
-    # rubocop:enable Style/AlignParameters
+    config_attr :undocumented_text,
+      command_line: '--undocumented-text UNDOCUMENTED_TEXT',
+      description: 'Default text for undocumented functions and  properties. '\
+                   'If you want no text, put "", default is "Undocumented"',
+      default: 'Undocumented'
+
+    # rubocop:enable Style/AlignParameter
 
     def initialize
       self.class.all_config_attrs.each do |attr|

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -330,8 +330,8 @@ module Jazzy
 
     config_attr :undocumented_text,
       command_line: '--undocumented-text UNDOCUMENTED_TEXT',
-      description: 'Default text for undocumented functions and  properties. '\
-                   'If you want no text, put "", default is "Undocumented"',
+      description: 'Default text for undocumented symbols. The default '\
+                   'is "Undocumented", put "" if no text is required',
       default: 'Undocumented'
 
     # rubocop:enable Style/AlignParameter

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -283,11 +283,9 @@ module Jazzy
       if objc || should_mark_undocumented(doc['key.kind'], filepath)
         @stats.add_undocumented(declaration)
         return nil if @skip_undocumented
-        if Config.instance.undocumented_text_configured
-          declaration.abstract = Config.instance.undocumented_text
-        else
-          declaration.abstract = @undocumented_abstract
-        end
+        declaration.abstract = Config.instance.undocumented_text_configured ? 
+                               Config.instance.undocumented_text :
+                               @undocumented_abstract
       else
         comment = doc['key.doc.comment']
         declaration.abstract = Markdown.render(comment) if comment

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -48,7 +48,8 @@ end
 module Jazzy
   # This module interacts with the sourcekitten command-line executable
   module SourceKitten
-    @undocumented_abstract = Markdown.render(Config.instance.undocumented_text).freeze
+    @undocumented_abstract = Markdown.render(Config.instance.undocumented_text)
+	    .freeze
 
     # Group root-level docs by custom categories (if any) and type
     def self.group_docs(docs)
@@ -282,9 +283,9 @@ module Jazzy
       if objc || should_mark_undocumented(doc['key.kind'], filepath)
         @stats.add_undocumented(declaration)
         return nil if @skip_undocumented
-	if (Config.instance.undocumented_text_configured)
-	  declaration.abstract = Config.instance.undocumented_text
-	else
+        if Config.instance.undocumented_text_configured
+          declaration.abstract = Config.instance.undocumented_text
+        else
           declaration.abstract = @undocumented_abstract
 	end
       else

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -49,7 +49,7 @@ module Jazzy
   # This module interacts with the sourcekitten command-line executable
   module SourceKitten
     @undocumented_abstract = Markdown.render(Config.instance.undocumented_text)
-	    .freeze
+                                     .freeze
 
     # Group root-level docs by custom categories (if any) and type
     def self.group_docs(docs)
@@ -287,7 +287,7 @@ module Jazzy
           declaration.abstract = Config.instance.undocumented_text
         else
           declaration.abstract = @undocumented_abstract
-	end
+        end
       else
         comment = doc['key.doc.comment']
         declaration.abstract = Markdown.render(comment) if comment

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -283,9 +283,11 @@ module Jazzy
       if objc || should_mark_undocumented(doc['key.kind'], filepath)
         @stats.add_undocumented(declaration)
         return nil if @skip_undocumented
-        declaration.abstract = Config.instance.undocumented_text_configured ? 
-                               Config.instance.undocumented_text :
-                               @undocumented_abstract
+        if Config.instance.undocumented_text_configured
+          declaration.abstract = Config.instance.undocumented_text
+        else
+          declaration.abstract = @undocumented_abstract
+        end
       else
         comment = doc['key.doc.comment']
         declaration.abstract = Markdown.render(comment) if comment

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -48,7 +48,7 @@ end
 module Jazzy
   # This module interacts with the sourcekitten command-line executable
   module SourceKitten
-    @undocumented_abstract = Markdown.render('Undocumented').freeze
+    @undocumented_abstract = Markdown.render(Config.instance.undocumented_text).freeze
 
     # Group root-level docs by custom categories (if any) and type
     def self.group_docs(docs)
@@ -282,7 +282,11 @@ module Jazzy
       if objc || should_mark_undocumented(doc['key.kind'], filepath)
         @stats.add_undocumented(declaration)
         return nil if @skip_undocumented
-        declaration.abstract = @undocumented_abstract
+	if (Config.instance.undocumented_text_configured)
+	  declaration.abstract = Config.instance.undocumented_text
+	else
+          declaration.abstract = @undocumented_abstract
+	end
       else
         comment = doc['key.doc.comment']
         declaration.abstract = Markdown.render(comment) if comment

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -48,8 +48,11 @@ end
 module Jazzy
   # This module interacts with the sourcekitten command-line executable
   module SourceKitten
-    @undocumented_abstract = Markdown.render(Config.instance.undocumented_text)
-                                     .freeze
+    def self.undocumented_abstract
+      @undocumented_abstract ||= Markdown.render(
+        Config.instance.undocumented_text,
+      ).freeze
+    end
 
     # Group root-level docs by custom categories (if any) and type
     def self.group_docs(docs)
@@ -283,11 +286,7 @@ module Jazzy
       if objc || should_mark_undocumented(doc['key.kind'], filepath)
         @stats.add_undocumented(declaration)
         return nil if @skip_undocumented
-        if Config.instance.undocumented_text_configured
-          declaration.abstract = Config.instance.undocumented_text
-        else
-          declaration.abstract = @undocumented_abstract
-        end
+        declaration.abstract = undocumented_abstract
       else
         comment = doc['key.doc.comment']
         declaration.abstract = Markdown.render(comment) if comment


### PR DESCRIPTION
Small change: made the text for undocumented text configurable

1) Added a config option: undocumented_text
2) used that config option as the description text if set for undocumented functions

This should not change the default behavior (if you do not set the option) and I verified it worked with the option in both command line and config file.