### PR TITLE
Don't create documentation for generic type params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,7 @@ Metrics/BlockLength:
 Style/NumericPredicate:
   Enabled: false
 
-Style/IndentHeredoc:
+Layout/IndentHeredoc:
   Enabled: false
 
 # We adopted raise instead of fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#910](https://github.com/realm/jazzy/issues/910)
 
+* Don't create documentation nodes for generic type parameters.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#878](https://github.com/realm/jazzy/issues/878)
+
 ## 0.9.0
 
 ##### Breaking

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -73,7 +73,7 @@ module Jazzy
       end
 
       def should_document?
-        declaration? && !param?
+        declaration? && !param? && !generic_type_param?
       end
 
       def declaration?
@@ -102,6 +102,10 @@ module Jazzy
         # variables, so both kinds represent a parameter in jazzy.
         kind == 'source.lang.swift.decl.var.parameter' ||
           kind == 'source.lang.swift.decl.var.local'
+      end
+
+      def generic_type_param?
+        kind == 'source.lang.swift.decl.generic_type_param'
       end
 
       def objc_unexposed?

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -272,10 +272,9 @@ module Jazzy
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
 
-    def self.should_mark_undocumented(kind, filepath)
+    def self.should_mark_undocumented(filepath)
       source_directory = Config.instance.source_directory.to_s
-      (filepath || '').start_with?(source_directory) &&
-        kind != 'source.lang.swift.decl.generic_type_param'
+      (filepath || '').start_with?(source_directory)
     end
 
     def self.process_undocumented_token(doc, declaration)
@@ -283,7 +282,7 @@ module Jazzy
 
       filepath = doc['key.filepath']
       objc = Config.instance.objc_mode
-      if objc || should_mark_undocumented(doc['key.kind'], filepath)
+      if objc || should_mark_undocumented(filepath)
         @stats.add_undocumented(declaration)
         return nil if @skip_undocumented
         declaration.abstract = undocumented_abstract


### PR DESCRIPTION
From #878.  Generic type param nodes appear intermittently in the doc structure as children of functions and cause extra html pages to be created.  Just skip them.

Spec changes show effect on misc_jazzy_features - with an extra change there to continue exercising the safe-filenames feature.