### PR TITLE
Update to latest Rouge for better highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   [Ibrahim Ulukaya](https://github.com/ulukaya)
   [#828](https://github.com/realm/jazzy/issues/828)
 
+* Automatically use Swift or Objective-C syntax highlighting for code blocks
+  in documentation comments.  Improve Swift highlighting with latest Rouge.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#218](https://github.com/realm/jazzy/issues/218)
+
 ##### Bug Fixes
 
 * Fix Swift declarations when generating Objective-C docs for generic types.  

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       mustache (~> 0.99)
       open4
       redcarpet (~> 3.2)
-      rouge (~> 1.5)
+      rouge (>= 2.0.6, < 4.0)
       sass (~> 3.4)
       sqlite3 (~> 1.3)
       xcinvoke (~> 0.3.0)
@@ -130,7 +130,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
-    rouge (1.11.1)
+    rouge (3.0.0)
     rubocop (0.49.0)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)

--- a/jazzy.gemspec
+++ b/jazzy.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mustache', '~> 0.99'
   spec.add_runtime_dependency 'open4'
   spec.add_runtime_dependency 'redcarpet', '~> 3.2'
-  spec.add_runtime_dependency 'rouge', '~> 1.5'
+  spec.add_runtime_dependency 'rouge', ['>= 2.0.6', '< 4.0']
   spec.add_runtime_dependency 'sass', '~> 3.4'
   spec.add_runtime_dependency 'sqlite3', '~> 1.3'
   spec.add_runtime_dependency 'xcinvoke', '~> 0.3.0'

--- a/lib/jazzy/highlighter.rb
+++ b/lib/jazzy/highlighter.rb
@@ -3,8 +3,30 @@ require 'rouge'
 module Jazzy
   # This module helps highlight code
   module Highlighter
-    def self.highlight(source, language)
-      source && Rouge.highlight(source, language, 'html')
+    class Formatter < Rouge::Formatters::HTML
+      def initialize(language)
+        @language = language
+        super()
+      end
+
+      def stream(tokens, &b)
+        yield "<pre class=\"highlight #{@language}\"><code>"
+        super
+        yield "</code></pre>\n"
+      end
+    end
+
+    # What Rouge calls the language
+    def self.default_language
+      if Config.instance.objc_mode
+        'objective_c'
+      else
+        'swift'
+      end
+    end
+
+    def self.highlight(source, language = default_language)
+      source && Rouge.highlight(source, language, Formatter.new(language))
     end
   end
 end

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -8,6 +8,8 @@ module Jazzy
       include Redcarpet::Render::SmartyPants
       include Rouge::Plugins::Redcarpet
 
+      attr_accessor :default_language
+
       def header(text, header_level)
         text_slug = text.gsub(/[^\w]+/, '-')
                         .downcase
@@ -96,6 +98,14 @@ module Jazzy
         str << text
         str << (list_type == :ordered ? "</ol>\n" : "</ul>\n")
       end
+
+      def block_code(code, language)
+        super(code, language || default_language)
+      end
+
+      def rouge_formatter(lexer)
+        Highlighter::Formatter.new(lexer.tag)
+      end
     end
 
     REDCARPET_OPTIONS = {
@@ -161,8 +171,9 @@ module Jazzy
       @markdown ||= Redcarpet::Markdown.new(renderer, REDCARPET_OPTIONS)
     end
 
-    def self.render(markdown_text)
+    def self.render(markdown_text, default_language = nil)
       renderer.reset
+      renderer.default_language = default_language
       markdown.render(markdown_text)
     end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -287,8 +287,8 @@ module Jazzy
         return nil if @skip_undocumented
         declaration.abstract = undocumented_abstract
       else
-        comment = doc['key.doc.comment']
-        declaration.abstract = Markdown.render(comment) if comment
+        declaration.abstract = Markdown.render(doc['key.doc.comment'] || '',
+                                               Highlighter.default_language)
       end
 
       declaration
@@ -305,13 +305,11 @@ module Jazzy
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def self.make_doc_info(doc, declaration)
       return unless should_document?(doc)
 
       declaration.declaration = Highlighter.highlight(
         doc['key.parsed_declaration'] || doc['key.doc.declaration'],
-        Config.instance.objc_mode ? 'objc' : 'swift',
       )
       if Config.instance.objc_mode && doc['key.swift_declaration']
         declaration.other_language_declaration = Highlighter.highlight(
@@ -323,7 +321,8 @@ module Jazzy
         return process_undocumented_token(doc, declaration)
       end
 
-      declaration.abstract = Markdown.render(doc['key.doc.comment'] || '')
+      declaration.abstract = Markdown.render(doc['key.doc.comment'] || '',
+                                             Highlighter.default_language)
       declaration.discussion = ''
       declaration.return = Markdown.rendered_returns
       declaration.parameters = parameters(doc, Markdown.rendered_parameters)
@@ -331,7 +330,6 @@ module Jazzy
       @stats.add_documented
     end
     # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
 
     def self.make_substructure(doc, declaration)
       declaration.children = if doc['key.substructure']


### PR DESCRIPTION
This PR supports latest Rouge covering Swift 3 (including `open`, `fileprivate`) and all kinds of other things.

The jazzy code changes are to handle changes to the Rouge API/behaviour:
1. None of the built-in formatters generate exactly the HTML + CSS that jazzy expects.
2. Rouge 3 stopped being able to auto-guess Objective-C.  To work around this the PR explicitly sets the default language for markdown code blocks.

The spec diffs are voluminous due to all the highlighting changes, plus all the code-highlight blocks are now styled identically: previously the declaration highlights did not include the language name as a CSS style, but the markdown blocks did; now they all do.

Can see examples of the highlighter in eg. the index pages; [RLMArray addNotificationBlock] docs show the auto-language part.

I tested this with rouge 2.0.6 as well as 3.0.0 (latest) and the only spec differences were to highlighting of `shell` code.