### PR TITLE
Drop Sass dependency to pre-3.5 to avoid ffi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Temporarily force ffi to 1.9.18 to avoid macOS build failures.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#941](https://github.com/realm/jazzy/issues/941)
 
 ## 0.9.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     jazzy (0.9.1)
       cocoapods (~> 1.0)
+      ffi (= 1.9.18)
       mustache (~> 0.99)
       open4
       redcarpet (~> 3.2)
@@ -186,4 +187,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/jazzy.gemspec
+++ b/jazzy.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   << 'jazzy'
 
   spec.add_runtime_dependency 'cocoapods', '~> 1.0'
+  spec.add_runtime_dependency 'ffi', '= 1.9.18'
   spec.add_runtime_dependency 'mustache', '~> 0.99'
   spec.add_runtime_dependency 'open4'
   spec.add_runtime_dependency 'redcarpet', '~> 3.2'


### PR DESCRIPTION
See #941 - I was hoping ffi would release a working version before too many people noticed this but it's been over a week now.

If you think it's worth doing a jazzy release in the interim then this patch pins ffi to the version jazzy has been using until a week ago ~cuts out the ffi dependency by back-levelling Sass to last summer~ -- doesn't change anything in the jazzy output.