### PR TITLE
Keep MARKs before extensions and enum cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Preserve `MARK` comment headings associated with extensions and enum cases.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ## 0.9.1
 

--- a/lib/jazzy/source_mark.rb
+++ b/lib/jazzy/source_mark.rb
@@ -27,5 +27,15 @@ module Jazzy
 
       self.name = mark_string[start_index..end_index]
     end
+
+    def empty?
+      !name && !has_start_dash && !has_end_dash
+    end
+
+    def copy(other)
+      self.name = other.name
+      self.has_start_dash = other.has_start_dash
+      self.has_end_dash = other.has_end_dash
+    end
   end
 end


### PR DESCRIPTION
This PR preserves MARK comments that are currently ignored in a couple of places:

1) Before enum cases: accidentally dropped here because of the way SourceKit presents them.
    This also gets rid of the extra vertical spacing between enum cases so they look a bit better.

2) Before extension declarations.  It's natural/common to put a MARK: before the `extension`.
     This gets lost by jazzy as it merges the extension into the extended type.  With this PR the MARK is
     basically moved just inside the extension so it shows up in the extended type method list.

```swift
class P {}                           class P {}

// MARK: Stuff                       extension P {
extension P {      == as though ==>    // MARK: Stuff
    func stuff()                       func stuff()
}                                    }
```
If there already is a MARK just inside the extension then that is kept & 'wins'.

Spec changes show these things affecting the docs, I think they're all improvements with MARK comments showing up for the first time that make sense.