### PR TITLE
Fix Dash docset index creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ##### Bug Fixes
 
 * Fix issue where Overview items were invalidly being referenced with NULL
-  types in the generated Dash docset index.
+  types in the generated Dash docset index.  
   [Andrew De Ponte](https://github.com/cyphactor)
   [#951](https://github.com/realm/jazzy/pull/951)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix issue where Overview items were invalidly being referenced with NULL
+  types in the generated Dash docset index.
+  [Andrew De Ponte](https://github.com/cyphactor)
+  [#951](https://github.com/realm/jazzy/pull/951)
 
 ## 0.9.1
 

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -5,7 +5,7 @@ module Jazzy
     # rubocop:disable Metrics/ClassLength
     class Type
       def self.all
-        TYPES.keys.reject { |k| k == 'Overview' }.map { |k| new(k) }
+        TYPES.reject { |_, v| v[:jazzy].nil? }.map { |k, _| new(k) }
       end
 
       attr_reader :kind

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -5,7 +5,7 @@ module Jazzy
     # rubocop:disable Metrics/ClassLength
     class Type
       def self.all
-        TYPES.keys.map { |k| new(k) }
+        TYPES.keys.reject { |k| k == 'Overview' }.map { |k| new(k) }
       end
 
       attr_reader :kind
@@ -130,6 +130,11 @@ module Jazzy
         'document.markdown' => {
           jazzy: 'Guide',
           dash: 'Guide',
+        }.freeze,
+
+        'Overview' => {
+          jazzy: nil,
+          dash: 'Section',
         }.freeze,
 
         # Objective-C


### PR DESCRIPTION
Prior to this Overview items were being represented in the Dash docset
index with a NULL type. Dash doesn't support indexes with NULL types in
them. To correct this I added an 'Overview' kind to the kind-type map
with a dash type of 'Section'. I talked about using this type with
Kapeli (the Dash developer) here,
https://github.com/Kapeli/Dash-User-Contributions/pull/1815 to see
if 'Section' was the appropriate type and it was.

This also includes new commit reference for the integration_specs which
I adjusted for this change as well. That pull request is open here,
https://github.com/realm/jazzy-integration-specs/pull/47