### PR TITLE
Build specs with Xcode9.3/Swift 4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
 
   swift:
     macos:
-      xcode: "9.2.0"
+      xcode: "9.3.0"
     environment: *bundler-environment
     # Used to invoke chruby
     shell: *shell
@@ -38,7 +38,7 @@ jobs:
 
   objc:
     macos:
-      xcode: "9.2.0"
+      xcode: "9.3.0"
     environment: *bundler-environment
     # Used to invoke chruby
     shell: *shell
@@ -53,7 +53,7 @@ jobs:
 
   cocoapods:
     macos:
-      xcode: "9.2.0"
+      xcode: "9.3.0"
     environment: *bundler-environment
     # Used to invoke chruby
     shell: *shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 9.2 installed to build the integration specs.
+You must have Xcode 9.3 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -210,8 +210,8 @@ describe_cli 'jazzy' do
       behaves_like cli_spec 'document_siesta',
                             # Siesta already has Docs/
                             '--output api-docs',
-                            # Use Swift 4.0.2 rather than the specified 3.0.2
-                            '--swift-version=4.0.3'
+                            # Use Swift 4.1 rather than the specified 3.0.2
+                            '--swift-version=4.1'
     end
 
     describe 'Creates docs for Swift project with a variety of contents' do


### PR DESCRIPTION
Switch to Xcode93/Swift 4.1 seeing as Xcode94 beta is here....
* Lots of name mangling/USR-naming changes;
* SourceKit[ten] now pick up all `subscript` and `typealias` declarations even without doc comments;
* Some @available attributes showing up that didn't before.