### PR TITLE
Stop hard-coding theme names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   Swift version.  
   [JP Simard](https://github.com/jpsim)
 
+* Fix jony theme selection.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#962](https://github.com/realm/jazzy/issues/962)
+
 ## 0.9.2
 
 ##### Breaking

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -313,15 +313,19 @@ module Jazzy
       description: 'Custom HTML to inject into <head></head>.',
       default: ''
 
+    BUILTIN_THEME_DIR = Pathname(__FILE__).parent + 'themes'
+    BUILTIN_THEMES = BUILTIN_THEME_DIR.children(false).map(&:to_s)
+
     config_attr :theme_directory,
-      command_line: '--theme [apple | fullwidth | jony | DIRPATH]',
+      command_line: "--theme [#{BUILTIN_THEMES.join(' | ')} | DIRPATH]",
       description: "Which theme to use. Specify either 'apple' (default), "\
-                   "'fullwidth', 'jony' or the path to your mustache " \
-                   'templates and other assets for a custom theme.',
+                   'one of the other built-in theme names, or the path to '\
+                   'your mustache templates and other assets for a custom '\
+                   'theme.',
       default: 'apple',
       parse: ->(t) do
-        if %w[apple fullwidth].include?(t)
-          Pathname(__FILE__).parent + 'themes' + t
+        if BUILTIN_THEMES.include?(t)
+          BUILTIN_THEME_DIR + t
         else
           expand_path(t)
         end


### PR DESCRIPTION
Stop hard-coding the theme names (multiple times!) in the source code -- I certainly didn't notice that
the important location hadn't been updated.  Fixes #962.

Also update one of the test projects to use the jony theme to spot future changes to it.