### PR TITLE
Prefer filesystem spelling of pathnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix crash with pre-existing `Docs` directory.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#965](https://github.com/realm/jazzy/issues/965)
 
 ## 0.9.3
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -87,7 +87,8 @@ module Jazzy
     attr_accessor :base_path
 
     def expand_path(path)
-      Pathname(path).expand_path(base_path) # nil means Pathname.pwd
+      abs_path = Pathname(path).expand_path(base_path) # nil means Pathname.pwd
+      Pathname(Dir[abs_path][0] || abs_path) # Use existing filesystem spelling
     end
 
     # ──────── Build ────────


### PR DESCRIPTION
Fix #965 - use the filesystem spelling of paths as canonical.  Tested locally with cases that would crash before.

@SDGGiesbrecht from previous bugs of mine I think you have access to a case-sensitive config, if so would you mind trying out this patch at some point just to check there's nothing broken there (should be fine...) 