### PR TITLE
Do not crash with bad declaration XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#965](https://github.com/realm/jazzy/issues/965)
 
+* Fix crash with unicode scalars in string literals.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#972](https://github.com/realm/jazzy/issues/972)
+
 ## 0.9.3
 
 ##### Breaking

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -339,6 +339,8 @@ module Jazzy
     def self.xml_to_text(xml)
       document = REXML::Document.new(xml)
       REXML::XPath.match(document.root, '//text()').map(&:value).join
+    rescue
+      ''
     end
 
     # Regexp to match an @attribute.  Complex to handle @available().
@@ -372,10 +374,11 @@ module Jazzy
     end
 
     def self.prefer_parsed_decl?(parsed, annotated)
-      parsed &&
-        (annotated.include?(' = default') || # SR-2608
-         parsed.match('@autoclosure|@escaping') || # SR-6321
-         parsed.include?("\n"))
+      annotated.empty? ||
+        parsed &&
+          (annotated.include?(' = default') || # SR-2608
+           parsed.match('@autoclosure|@escaping') || # SR-6321
+           parsed.include?("\n"))
     end
 
     # Replace the fully qualified name of a type with its base name


### PR DESCRIPTION
This fixes #972 by handling any error found parsing the source kit declaration XML and falling back to the parsed declaration.  Add a test.