### PR TITLE
[WIP] Allow nested categories with recursive navigation.

### DIFF
--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -99,6 +99,8 @@ module Jazzy
     attr_accessor :end_line
     attr_accessor :nav_order
     attr_accessor :url_name
+    attr_accessor :level
+    attr_accessor :subsections
 
     def alternative_abstract
       if file = alternative_abstract_file

--- a/lib/jazzy/themes/fullwidth/templates/doc.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/doc.mustache
@@ -45,6 +45,9 @@
               </div>
             {{/declaration}}
             {{{overview}}}
+            {{#subsections}}
+              {{> subsection}}
+            {{/subsections}}
           </div>
         </section>
 

--- a/lib/jazzy/themes/fullwidth/templates/nav.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/nav.mustache
@@ -1,16 +1,7 @@
 <nav class="navigation">
   <ul class="nav-groups">
     {{#structure}}
-    <li class="nav-group-name">
-      <a class="nav-group-name-link" href="{{path_to_root}}{{url}}">{{section}}</a>
-      <ul class="nav-group-tasks">
-        {{#children}}
-        <li class="nav-group-task">
-          <a class="nav-group-task-link" href="{{path_to_root}}{{url}}">{{name}}</a>
-        </li>
-        {{/children}}
-      </ul>
-    </li>
+      {{> nav_section}}
     {{/structure}}
   </ul>
 </nav>

--- a/lib/jazzy/themes/fullwidth/templates/nav_section.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/nav_section.mustache
@@ -1,0 +1,15 @@
+<li class="nav-group-name">
+  <a class="nav-group-name-link" href="{{path_to_root}}{{url}}"><h{{level}}>{{section}}</h{{level}}></a>
+  <ul class="nav-group-tasks">
+    {{#children}}
+    <li class="nav-group-task">
+      <a class="nav-group-task-link" href="{{path_to_root}}{{url}}">{{name}}</a>
+    </li>
+    {{/children}}
+  </ul>
+  <ul class="nav-groups">
+    {{#subsections}}
+      {{> nav_section}}
+    {{/subsections}}
+  </ul>
+</li>

--- a/lib/jazzy/themes/fullwidth/templates/subsection.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/subsection.mustache
@@ -1,0 +1,5 @@
+<h{{level}}>{{name}}</h{{level}}>
+{{{overview}}}
+{{#subsections}}
+  {{> subsection}}
+{{/subsections}}

--- a/lib/jazzy/themes/fullwidth/templates/tasks.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/tasks.mustache
@@ -7,3 +7,4 @@
   </div>
 </section>
 {{/tasks.count}}
+{{structure}}


### PR DESCRIPTION
## Overview
So I started working on allowing nested categories for custom categories. Currently there is no limit on the amount of nesting (i.e. levels). This is achieved through nested partials as well as keeping track of the level, and using that in the header tag (`<h{{level}}>`).

## Current Implementation
- I only hacked together the css & templates for fullwidth. The theme changes aren't that drastic and I will try to keep it backwards compatible.
- The css needs some rework, not that good at css.
- Subsections are added as a separate property on the doc_model object.
- Name and overview for a subsection (and subsubsection) is emitted before the tasks. See screenshots

## Questions
- Would the better option be adding the subsections to the children property instead of it's own? And then doing something like this in mustache?:
```
<li class="nav-group-name">
  <a class="nav-group-name-link" href="{{path_to_root}}{{url}}"><h{{level}}>{{section}}</h{{level}}></a>
  <ul class="nav-group-tasks">
    {{#children}}
      {{#children.count}}
  <ul class="nav-groups">
    {{#children}}
      {{> nav_section}}
    {{/children}}
  </ul>
      {{/children.count}}
      {{^children.count}}
    <li class="nav-group-task">
      <a class="nav-group-task-link" href="{{path_to_root}}{{url}}">{{name}}</a>
    </li>
    {{/children.count}}
  </ul>
</li>
```
- This however would then create complications with tasks, or would it?
- Should the full subsection be rendered out before the tasks come? IMO this would get quite lengthy with a lot of sub and subsubsections.
- Should the default theme autohide subsubsections (or even subsections)? i.e. make it show on clicking the parent section?
- Should there be no indentation in the navigation menu?
- Should I add some tests?

Generally, I would really appreciate some help with the css and generally the look & feel.

## Screenshots
![screen shot 2018-06-15 at 22 45 00](https://user-images.githubusercontent.com/5339762/41488888-3968bf96-70ee-11e8-8e63-9c1eb82a91d3.png)
![screen shot 2018-06-15 at 22 45 28](https://user-images.githubusercontent.com/5339762/41488890-399db6d8-70ee-11e8-86cd-8a3f17a63825.png)
![screen shot 2018-06-15 at 22 45 17](https://user-images.githubusercontent.com/5339762/41488889-39823584-70ee-11e8-8463-a65d994679d2.png)


Created with the following yaml:
```
module: TestFramework
abstract: Documentation/*.md
documentation: Guide.md
output: docs
theme: fullwidth
custom_categories:
  - name: Main
    children:
      - Test
      - name: Sub
        children:
          - WithEnum
          - name: SubSub
            children:
              - Guide
```

## Linked
Closes #624