### PR TITLE
Minimize the amount of specs being built by jazzy and improve checking which targets to build.

### DIFF
--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -21,8 +21,13 @@ module Jazzy
         installer = Pod::Installer.new(sandbox, podfile)
         installer.install!
         stdout = Dir.chdir(sandbox.root) do
+          specs_being_built = []
           targets = installer.pod_targets
-                             .select { |pt| pt.pod_name == podspec.root.name }
+                             .select do |pt|
+                               select = pt.specs[0].root == podspec.root && pt.specs.any? { |spec| !specs_being_built.include?(spec) }
+                               specs_being_built.push(*pt.specs)
+                               select
+                             end
                              .map(&:label)
 
           targets.map do |t|


### PR DESCRIPTION
This PR aims to improve jazzy's podspec integration in a few ways:

1. Jazzy will try to build specs as few times as possible. By keeping track of what specs are already built by previous targets, it can skip targets that only include specs of other targets (Mostly subspecs). If there are subspecs that have a dependency on other subspecs, this can still lead to jazzy running for a spec multiple times. However, that should be relatively rare and only happen when the default_subspecs are set.
2. Instead of checking the pod_name of a target and seeing if it matches, jazzy will take the first spec of a target and see whether the root of that target is the root of the podspec.

Let me know, if and where to add some tests for this as well as whether I should add a config option to only document certain subspecs.

Also should I refactor this? Rubocop complains that the method is too long.

Fixes #981