### PR TITLE
Mark unavailable and deprecated symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Enhancements
 
-* None.
+* Shows unavailable and deprecated symbols in the generated documentation via a strikethrough text attribute.
+  [Stefan Kieleithner](https://github.com/steviki)
+  [#843](https://github.com/realm/jazzy/issues/843)
 
 ##### Bug Fixes
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -350,6 +350,9 @@ module Jazzy
         url:                        (item.url if item.children.any?),
         start_line:                 item.start_line,
         end_line:                   item.end_line,
+        deprecation_message:        (item.deprecation_message if item.deprecated),
+        unavailable_message:        (item.unavailable_message if item.unavailable),
+        usage_discouraged:          item.deprecated || item.unavailable,
       }
     end
 

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -99,6 +99,10 @@ module Jazzy
     attr_accessor :end_line
     attr_accessor :nav_order
     attr_accessor :url_name
+    attr_accessor :deprecated
+    attr_accessor :deprecation_message
+    attr_accessor :unavailable
+    attr_accessor :unavailable_message
 
     def alternative_abstract
       if file = alternative_abstract_file

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -332,6 +332,9 @@ module Jazzy
       declaration.return = Markdown.rendered_returns
       declaration.parameters = parameters(doc, Markdown.rendered_parameters)
 
+      declaration.deprecation_message = Markdown.render(doc['key.deprecation_message'] || '', Highlighter.default_language)
+      declaration.unavailable_message = Markdown.render(doc['key.unavailable_message'] || '', Highlighter.default_language)
+
       @stats.add_documented
     end
 
@@ -482,6 +485,8 @@ module Jazzy
         declaration.column = doc['key.doc.column']
         declaration.start_line = doc['key.parsed_scope.start']
         declaration.end_line = doc['key.parsed_scope.end']
+        declaration.deprecated = doc['key.always_deprecated']
+        declaration.unavailable = doc['key.always_unavailable']
 
         next unless make_doc_info(doc, declaration)
         make_substructure(doc, declaration)

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -754,6 +754,8 @@ module Jazzy
 
         doc.return = autolink_text(doc.return, doc, root_decls) if doc.return
         doc.abstract = autolink_text(doc.abstract, doc, root_decls)
+        doc.unavailable_message = autolink_text(doc.unavailable_message, doc, root_decls) if doc.unavailable_message
+        doc.deprecation_message = autolink_text(doc.deprecation_message, doc, root_decls) if doc.deprecation_message
         (doc.parameters || []).each do |param|
           param[:discussion] =
             autolink_text(param[:discussion], doc, root_decls)

--- a/lib/jazzy/themes/apple/templates/task.mustache
+++ b/lib/jazzy/themes/apple/templates/task.mustache
@@ -15,7 +15,12 @@
         <code>
         <a name="/{{usr}}"></a>
         <a name="//apple_ref/{{language_stub}}/{{dash_type}}/{{name}}" class="dashAnchor"></a>
+        {{^usage_discouraged}}
         <a class="token" href="#/{{usr}}">{{name}}</a>
+        {{/usage_discouraged}}
+        {{#usage_discouraged}}
+        <a class="token" href="#/{{usr}}"><strike>{{name}}</strike></a>
+        {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}
           <span class="declaration-note">
@@ -32,6 +37,18 @@
         <div class="pointer-container"></div>
         <section class="section">
           <div class="pointer"></div>
+          {{#deprecation_message}}
+          <div class="aside">
+            <p class="aside-title">Deprecated</p>
+            {{{deprecation_message}}}
+          </div>
+          {{/deprecation_message}}
+          {{#unavailable_message}}
+          <div class="aside">
+            <p class="aside-title">Unavailable</p>
+            {{{unavailable_message}}}
+          </div>
+          {{/unavailable_message}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}

--- a/lib/jazzy/themes/fullwidth/templates/task.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/task.mustache
@@ -15,7 +15,12 @@
         <code>
         <a name="/{{usr}}"></a>
         <a name="//apple_ref/{{language_stub}}/{{dash_type}}/{{name}}" class="dashAnchor"></a>
+        {{^usage_discouraged}}
         <a class="token" href="#/{{usr}}">{{name}}</a>
+        {{/usage_discouraged}}
+        {{#usage_discouraged}}
+        <a class="token" href="#/{{usr}}"><strike>{{name}}</strike></a>
+        {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}
           <span class="declaration-note">
@@ -32,6 +37,18 @@
         <div class="pointer-container"></div>
         <section class="section">
           <div class="pointer"></div>
+          {{#deprecation_message}}
+          <div class="aside">
+            <p class="aside-title">Deprecated</p>
+            {{{deprecation_message}}}
+          </div>
+          {{/deprecation_message}}
+          {{#unavailable_message}}
+          <div class="aside">
+            <p class="aside-title">Unavailable</p>
+            {{{unavailable_message}}}
+          </div>
+          {{/unavailable_message}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}

--- a/lib/jazzy/themes/jony/templates/task.mustache
+++ b/lib/jazzy/themes/jony/templates/task.mustache
@@ -15,7 +15,12 @@
         <code>
         <a name="/{{usr}}"></a>
         <a name="//apple_ref/{{language_stub}}/{{dash_type}}/{{name}}" class="dashAnchor"></a>
+        {{^usage_discouraged}}
         <a class="token" href="#/{{usr}}">{{name}}</a>
+        {{/usage_discouraged}}
+        {{#usage_discouraged}}
+        <a class="token" href="#/{{usr}}"><strike>{{name}}</strike></a>
+        {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}
           <span class="declaration-note">
@@ -32,6 +37,18 @@
         <div class="pointer-container"></div>
         <section class="section">
           <div class="pointer"></div>
+          {{#deprecation_message}}
+          <div class="aside">
+            <p class="aside-title">Deprecated</p>
+            {{{deprecation_message}}}
+          </div>
+          {{/deprecation_message}}
+          {{#unavailable_message}}
+          <div class="aside">
+            <p class="aside-title">Unavailable</p>
+            {{{unavailable_message}}}
+          </div>
+          {{/unavailable_message}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}


### PR DESCRIPTION
Fixes https://github.com/realm/jazzy/issues/843.

This PR adds the ability to detect unavailable and deprecated symbols, as well as the related messages.

In the generated documentation, an unavailable or deprecated symbol is marked with a strikethrough of its name, and adds a box with the unavailable message or the deprecated message when expanding the symbol.

We are already using this in production for the PSPDFKit for iOS API documentation. (See https://pspdfkit.com/api/ios/Classes/PSPDFDocumentViewLayout.html#/c:objc(cs)PSPDFDocumentViewLayout(py)pagingEnabled for an example of a deprecated API.)

<img width="889" alt="screen shot 2018-08-16 at 09 07 34" src="https://user-images.githubusercontent.com/5294262/44193633-d85a4a00-a133-11e8-91ae-e1f67d84d135.png">
