### PR TITLE
Fix error compiling Swift podspec in Xcode 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#972](https://github.com/realm/jazzy/issues/972)
 
+* Fix error compiling a Swift podspec in Xcode 10.  
+  [Minh Nguyễn](https://github.com/1ec5)
+  [#970](https://github.com/realm/jazzy/issues/970)
+
 ## 0.9.3
 
 ##### Breaking

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -28,7 +28,7 @@ module Jazzy
           targets.map do |t|
             args = %W[doc --module-name #{podspec.module_name} -- -target #{t}]
             swift_version = (config.swift_version || '4')[0] + '.0'
-            args << "SWIFT_VERSION=\"#{swift_version}\""
+            args << "SWIFT_VERSION=#{swift_version}"
             SourceKitten.run_sourcekitten(args)
           end
         end


### PR DESCRIPTION
Removed the extra quotes around the `SWIFT_VERSION` build setting to avoid an `xcodebuild` error under the new build system (i.e., Xcode 10).

Fixes #970.