### PR TITLE
Updates to build specs with Xcode10 / Swift 4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
 
   swift:
     macos:
-      xcode: "9.3.0"
+      xcode: "10.0.0"
     environment: *bundler-environment
     # Used to invoke chruby
     shell: *shell
@@ -38,7 +38,7 @@ jobs:
 
   objc:
     macos:
-      xcode: "9.3.0"
+      xcode: "10.0.0"
     environment: *bundler-environment
     # Used to invoke chruby
     shell: *shell
@@ -53,7 +53,7 @@ jobs:
 
   cocoapods:
     macos:
-      xcode: "9.3.0"
+      xcode: "10.0.0"
     environment: *bundler-environment
     # Used to invoke chruby
     shell: *shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 9.3 installed to build the integration specs.
+You must have Xcode 10.0 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -175,7 +175,7 @@ describe_cli 'jazzy' do
       behaves_like cli_spec 'document_alamofire',
                             '-m Alamofire -a Alamofire ' \
                             '-u https://nshipster.com/alamofire ' \
-                            '-x -project,Alamofire.xcodeproj,-dry-run ' \
+                            '-x -project,Alamofire.xcodeproj ' \
                             '-g https://github.com/Alamofire/Alamofire ' \
                             '--github-file-prefix https://github.com/' \
                             'Alamofire/Alamofire/blob/4.3.0 ' \


### PR DESCRIPTION
I created these as part of checking the podspec PR, may as well try to get CI updated.

New Xcode build system doesn't support `-dry-run` so took that out.

Spec changes I spotted:
1. USR generation has changed, almost all decls get a change.  No user change bar deep URLs.
2. The official name of enum case declarations now contains labels of any associated values, per SE-0155.  This means autolinks to enum cases with associated values will no longer work and will need updating.