### PR TITLE
Support Swift 4.2 with --podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Support Swift 4.2 with `--podspec`.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1015](https://github.com/realm/jazzy/issues/1015)
 
 ## 0.9.4
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,20 @@ Note that the `--include` option is applied before the `--exclude` option. For e
 Declarations with a documentation comment containing `:nodoc:` are excluded from the
 documentation.
 
+### Choosing the Swift language version
+
+Jazzy normally uses the Swift compiler from the Xcode currently configured by
+`xcode-select`.  Use the `--swift-version` flag to compile with a different
+Xcode.
+
+The value you pass to `--swift-version` must be the Swift language version given
+by `swift --version` in the Xcode you want to use.
+
+For example to use Xcode 9.4:
+```shell
+jazzy --swift-version 4.1.2
+```
+
 ## Troubleshooting
 
 #### Swift
@@ -226,6 +240,18 @@ documentation.
 **Only extensions are listed in the documentation?**
 
 Check the `--min-acl` setting -- see [above](#controlling-what-is-documented).
+
+**Unable to find an Xcode with swift version X**
+
+1. The value passed with `--swift-version` must exactly match the version
+   number from `swiftc --version`.  For example Xcode 10.1 needs
+   `--swift-version 4.2.1`.  See [the flag documentation](#choosing-the-swift-language-version).
+2. The Xcode you want to use must be in the Spotlight index.  You can check
+   this using `mdfind 'kMDItemCFBundleIdentifier == com.apple.dt.Xcode'`.
+   Some users have reported this issue being fixed by a reboot; `mdutil -E`
+   may also help.  If none of these work then you can set the `DEVELOPER_DIR`
+   environment variable to point to the Xcode you want before running Jazzy
+   without the `--swift-version` flag.
 
 #### Installation Problems
 

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -27,7 +27,7 @@ module Jazzy
 
           targets.map do |t|
             args = %W[doc --module-name #{podspec.module_name} -- -target #{t}]
-            swift_version = (config.swift_version || '4')[0] + '.0'
+            swift_version = compiler_swift_version(config.swift_version)
             args << "SWIFT_VERSION=#{swift_version}"
             SourceKitten.run_sourcekitten(args)
           end
@@ -96,6 +96,23 @@ module Jazzy
     end
 
     private_class_method :github_file_prefix
+
+    # Latest valid value for SWIFT_VERSION.
+    LATEST_SWIFT_VERSION = '4.2'.freeze
+
+    # All valid values for SWIFT_VERSION that are longer
+    # than a major version number.  Ordered ascending.
+    LONG_SWIFT_VERSIONS = ['4.2'].freeze
+
+    # Go from a full Swift version like 4.2.1 to
+    # something valid for SWIFT_VERSION.
+    def compiler_swift_version(user_version)
+      return LATEST_SWIFT_VERSION unless user_version
+
+      LONG_SWIFT_VERSIONS.select do |version|
+        user_version.start_with?(version)
+      end.last || "#{user_version[0]}.0"
+    end
 
     # @!group SourceKitten output helper methods
 


### PR DESCRIPTION
Generalize the code that figures out SWIFT_VERSION from the full swift version number to work properly with 4.2 and future maj/min values.  Update the default version to 4.2 for Xcode 10.

Can't see how to avoid hard-coding these numbers.

Write up what the `--swift-version` flag actually does (most of the added lines.)