### PR TITLE
Apple theme for multiline copyright string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#1015](https://github.com/realm/jazzy/issues/1015)
 
+* Fix multiline copyright for `apple` theme.  
+  [Fabien Lydoire](https://github.com/fabienlydoire)
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1016](https://github.com/realm/jazzy/issues/1016)
+
 ## 0.9.4
 
 ##### Breaking

--- a/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
@@ -240,7 +240,7 @@ header {
   margin-left: $content_body_left_offset;
   position: absolute;
   overflow: hidden;
-  padding-bottom: 60px;
+  padding-bottom: 20px;
   top: $content_top_offset;
   width: $content_wrapper_width - $content_body_left_offset;
   p, a, code, em, ul, table, blockquote {
@@ -446,8 +446,9 @@ header {
 }
 
 #footer {
-  position: absolute;
-  bottom: 10px;
+  position: relative;
+  top: 10px;
+  bottom: 0px;
   margin-left: 25px;
   p {
     margin: 0;


### PR DESCRIPTION
#1013 ctd to fix vertical spacing and update specs.  No visible effect for single-line copyright statements.

<img width="297" alt="screenshot 2019-01-17 at 17 26 07" src="https://user-images.githubusercontent.com/26768470/51336742-3d1c2680-1a7d-11e9-99a1-f562d139dfb3.png">
<img width="290" alt="screenshot 2019-01-17 at 17 26 29" src="https://user-images.githubusercontent.com/26768470/51336750-3ee5ea00-1a7d-11e9-8b01-fd7b80cf6d6f.png">
