### PR TITLE
Mark unavailable and deprecated symbols in ObjC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#730](https://github.com/realm/jazzy/issues/730)
 
+* Call out unavailable and deprecated Objective-C declarations.  
+  [Stefan Kieleithner](https://github.com/steviki)
+  [John Fairhurst](https://github.com/johnfairh)
+  [#843](https://github.com/realm/jazzy/issues/843)
+
 ##### Bug Fixes
 
 * Support Swift 4.2 with `--podspec`.  

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -350,6 +350,9 @@ module Jazzy
         start_line:                 item.start_line,
         end_line:                   item.end_line,
         direct_link:                item.omit_content_from_parent?,
+        deprecation_message:        (item.deprecation_message if item.deprecated),
+        unavailable_message:        (item.unavailable_message if item.unavailable),
+        usage_discouraged:          item.deprecated || item.unavailable,
       }
     end
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -331,6 +331,7 @@ module Jazzy
     # Build mustache item for a top-level doc
     # @param [Hash] item Parsed doc child item
     # @param [Config] options Build options
+    # rubocop:disable Metrics/MethodLength
     def self.render_item(item, source_module)
       # Combine abstract and discussion into abstract
       abstract = (item.abstract || '') + (item.discussion || '')
@@ -350,11 +351,12 @@ module Jazzy
         start_line:                 item.start_line,
         end_line:                   item.end_line,
         direct_link:                item.omit_content_from_parent?,
-        deprecation_message:        (item.deprecation_message if item.deprecated),
-        unavailable_message:        (item.unavailable_message if item.unavailable),
-        usage_discouraged:          item.deprecated || item.unavailable,
+        deprecation_message:        item.deprecation_message,
+        unavailable_message:        item.unavailable_message,
+        usage_discouraged:          item.usage_discouraged?,
       }
     end
+    # rubocop:enable Metrics/MethodLength
 
     def self.make_task(mark, uid, items)
       {

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -423,6 +423,9 @@ module Jazzy
       doc[:github_url] = source_module.github_url
       doc[:dash_url] = source_module.dash_url
       doc[:path_to_root] = path_to_root
+      doc[:deprecation_message] = doc_model.deprecation_message
+      doc[:unavailable_message] = doc_model.unavailable_message
+      doc[:usage_discouraged] = doc_model.usage_discouraged?
       doc.render.gsub(ELIDED_AUTOLINK_TOKEN, path_to_root)
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -107,6 +107,10 @@ module Jazzy
     attr_accessor :unavailable
     attr_accessor :unavailable_message
 
+    def usage_discouraged?
+      unavailable || deprecated
+    end
+
     def alternative_abstract
       if file = alternative_abstract_file
         Pathname(file).read

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -102,6 +102,10 @@ module Jazzy
     attr_accessor :end_line
     attr_accessor :nav_order
     attr_accessor :url_name
+    attr_accessor :deprecated
+    attr_accessor :deprecation_message
+    attr_accessor :unavailable
+    attr_accessor :unavailable_message
 
     def alternative_abstract
       if file = alternative_abstract_file

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -332,6 +332,9 @@ module Jazzy
       declaration.return = Markdown.rendered_returns
       declaration.parameters = parameters(doc, Markdown.rendered_parameters)
 
+      declaration.deprecation_message = Markdown.render(doc['key.deprecation_message'] || '', Highlighter.default_language)
+      declaration.unavailable_message = Markdown.render(doc['key.unavailable_message'] || '', Highlighter.default_language)
+
       @stats.add_documented
     end
 
@@ -482,6 +485,8 @@ module Jazzy
         declaration.column = doc['key.doc.column']
         declaration.start_line = doc['key.parsed_scope.start']
         declaration.end_line = doc['key.parsed_scope.end']
+        declaration.deprecated = doc['key.always_deprecated']
+        declaration.unavailable = doc['key.always_unavailable']
 
         next unless make_doc_info(doc, declaration)
         make_substructure(doc, declaration)
@@ -749,6 +754,8 @@ module Jazzy
 
         doc.return = autolink_text(doc.return, doc, root_decls) if doc.return
         doc.abstract = autolink_text(doc.abstract, doc, root_decls)
+        doc.unavailable_message = autolink_text(doc.unavailable_message, doc, root_decls) if doc.unavailable_message
+        doc.deprecation_message = autolink_text(doc.deprecation_message, doc, root_decls) if doc.deprecation_message
         (doc.parameters || []).each do |param|
           param[:discussion] =
             autolink_text(param[:discussion], doc, root_decls)

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -322,6 +322,8 @@ module Jazzy
           Highlighter.highlight(make_swift_declaration(doc, declaration))
       end
 
+      make_deprecation_info(doc, declaration)
+
       unless doc['key.doc.full_as_xml']
         return process_undocumented_token(doc, declaration)
       end
@@ -332,10 +334,18 @@ module Jazzy
       declaration.return = Markdown.rendered_returns
       declaration.parameters = parameters(doc, Markdown.rendered_parameters)
 
-      declaration.deprecation_message = Markdown.render(doc['key.deprecation_message'] || '', Highlighter.default_language)
-      declaration.unavailable_message = Markdown.render(doc['key.unavailable_message'] || '', Highlighter.default_language)
-
       @stats.add_documented
+    end
+
+    def self.make_deprecation_info(doc, declaration)
+      if declaration.deprecated
+        declaration.deprecation_message =
+          Markdown.render(doc['key.deprecation_message'] || '')
+      end
+      if declaration.unavailable
+        declaration.unavailable_message =
+          Markdown.render(doc['key.unavailable_message'] || '')
+      end
     end
 
     # Strip tags and convert entities
@@ -747,30 +757,34 @@ module Jazzy
       end
     end
 
+    AUTOLINK_TEXT_FIELDS = %w[return
+                              abstract
+                              unavailable_message
+                              deprecation_message].freeze
+
+    AUTOLINK_HIGHLIGHT_FIELDS = %w[declaration
+                                   other_language_declaration].freeze
+
     def self.autolink(docs, root_decls)
       @autolink_root_decls = root_decls
       docs.each do |doc|
         doc.children = autolink(doc.children, root_decls)
 
-        doc.return = autolink_text(doc.return, doc, root_decls) if doc.return
-        doc.abstract = autolink_text(doc.abstract, doc, root_decls)
-        doc.unavailable_message = autolink_text(doc.unavailable_message, doc, root_decls) if doc.unavailable_message
-        doc.deprecation_message = autolink_text(doc.deprecation_message, doc, root_decls) if doc.deprecation_message
+        AUTOLINK_TEXT_FIELDS.each do |field|
+          if text = doc.send(field)
+            doc.send(field + '=', autolink_text(text, doc, root_decls))
+          end
+        end
+
+        AUTOLINK_HIGHLIGHT_FIELDS.each do |field|
+          if text = doc.send(field)
+            doc.send(field + '=', autolink_text(text, doc, root_decls, true))
+          end
+        end
+
         (doc.parameters || []).each do |param|
           param[:discussion] =
             autolink_text(param[:discussion], doc, root_decls)
-        end
-
-        if doc.declaration
-          doc.declaration = autolink_text(
-            doc.declaration, doc, root_decls, true
-          )
-        end
-
-        if doc.other_language_declaration
-          doc.other_language_declaration = autolink_text(
-            doc.other_language_declaration, doc, root_decls, true
-          )
         end
       end
     end

--- a/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
@@ -412,7 +412,7 @@ header {
   }
 }
 
-.aside-warning {
+.aside-warning, .aside-deprecated, .aside-unavailable {
   border-left: $aside_warning_border;
   .aside-title {
     color: $aside_warning_color;

--- a/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
@@ -338,6 +338,9 @@ header {
     margin-left: 15px;
     font-size: 11.9px;
   }
+  .discouraged {
+    text-decoration: line-through;
+  }
   .declaration-note {
     font-size: .85em;
     color: rgba(128,128,128,1);

--- a/lib/jazzy/themes/apple/templates/deprecation.mustache
+++ b/lib/jazzy/themes/apple/templates/deprecation.mustache
@@ -1,0 +1,12 @@
+{{#deprecation_message}}
+<div class="aside aside-deprecated">
+  <p class="aside-title">Deprecated</p>
+  {{{deprecation_message}}}
+</div>
+{{/deprecation_message}}
+{{#unavailable_message}}
+<div class="aside aside-unavailable">
+  <p class="aside-title">Unavailable</p>
+  {{{unavailable_message}}}
+</div>
+{{/unavailable_message}}

--- a/lib/jazzy/themes/apple/templates/doc.mustache
+++ b/lib/jazzy/themes/apple/templates/doc.mustache
@@ -28,6 +28,7 @@
         <section>
           <section class="section">
             {{^hide_name}}<h1>{{name}}</h1>{{/hide_name}}
+            {{> deprecation}}
             {{#declaration}}
               <div class="declaration">
                 <div class="language">

--- a/lib/jazzy/themes/apple/templates/task.mustache
+++ b/lib/jazzy/themes/apple/templates/task.mustache
@@ -20,7 +20,12 @@
         </code>
         {{/direct_link}}
         {{^direct_link}}
+        {{^usage_discouraged}}
         <a class="token" href="#/{{usr}}">{{name}}</a>
+        {{/usage_discouraged}}
+        {{#usage_discouraged}}
+        <a class="token" href="#/{{usr}}"><strike>{{name}}</strike></a>
+        {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}
           <span class="declaration-note">
@@ -37,6 +42,18 @@
         <div class="pointer-container"></div>
         <section class="section">
           <div class="pointer"></div>
+          {{#deprecation_message}}
+          <div class="aside">
+            <p class="aside-title">Deprecated</p>
+            {{{deprecation_message}}}
+          </div>
+          {{/deprecation_message}}
+          {{#unavailable_message}}
+          <div class="aside">
+            <p class="aside-title">Unavailable</p>
+            {{{unavailable_message}}}
+          </div>
+          {{/unavailable_message}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}

--- a/lib/jazzy/themes/apple/templates/task.mustache
+++ b/lib/jazzy/themes/apple/templates/task.mustache
@@ -42,18 +42,7 @@
         <div class="pointer-container"></div>
         <section class="section">
           <div class="pointer"></div>
-          {{#deprecation_message}}
-          <div class="aside aside-deprecated">
-            <p class="aside-title">Deprecated</p>
-            {{{deprecation_message}}}
-          </div>
-          {{/deprecation_message}}
-          {{#unavailable_message}}
-          <div class="aside aside-unavailable">
-            <p class="aside-title">Unavailable</p>
-            {{{unavailable_message}}}
-          </div>
-          {{/unavailable_message}}
+          {{> deprecation}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}

--- a/lib/jazzy/themes/apple/templates/task.mustache
+++ b/lib/jazzy/themes/apple/templates/task.mustache
@@ -24,7 +24,7 @@
         <a class="token" href="#/{{usr}}">{{name}}</a>
         {{/usage_discouraged}}
         {{#usage_discouraged}}
-        <a class="token" href="#/{{usr}}"><strike>{{name}}</strike></a>
+        <a class="token discouraged" href="#/{{usr}}">{{name}}</a>
         {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}

--- a/lib/jazzy/themes/apple/templates/task.mustache
+++ b/lib/jazzy/themes/apple/templates/task.mustache
@@ -43,13 +43,13 @@
         <section class="section">
           <div class="pointer"></div>
           {{#deprecation_message}}
-          <div class="aside">
+          <div class="aside aside-deprecated">
             <p class="aside-title">Deprecated</p>
             {{{deprecation_message}}}
           </div>
           {{/deprecation_message}}
           {{#unavailable_message}}
-          <div class="aside">
+          <div class="aside aside-unavailable">
             <p class="aside-title">Unavailable</p>
             {{{unavailable_message}}}
           </div>

--- a/lib/jazzy/themes/fullwidth/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/fullwidth/assets/css/jazzy.css.scss
@@ -154,8 +154,14 @@ a {
     outline: 0;
     text-decoration: underline;
   }
-}
 
+  &.discouraged {
+    text-decoration: line-through;
+    &:hover, &:focus {
+      text-decoration: underline line-through;
+    }
+  }
+}
 
 // ----- Tables
 

--- a/lib/jazzy/themes/fullwidth/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/fullwidth/assets/css/jazzy.css.scss
@@ -479,7 +479,7 @@ pre code {
   }
 }
 
-.aside-warning {
+.aside-warning, .aside-deprecated, .aside-unavailable {
   border-left: $aside_warning_border;
   .aside-title {
     color: $aside_warning_color;

--- a/lib/jazzy/themes/fullwidth/templates/deprecation.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/deprecation.mustache
@@ -1,0 +1,12 @@
+{{#deprecation_message}}
+<div class="aside aside-deprecated">
+  <p class="aside-title">Deprecated</p>
+  {{{deprecation_message}}}
+</div>
+{{/deprecation_message}}
+{{#unavailable_message}}
+<div class="aside aside-unavailable">
+  <p class="aside-title">Unavailable</p>
+  {{{unavailable_message}}}
+</div>
+{{/unavailable_message}}

--- a/lib/jazzy/themes/fullwidth/templates/doc.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/doc.mustache
@@ -37,6 +37,7 @@
         <section class="section">
           <div class="section-content">
             {{^hide_name}}<h1>{{name}}</h1>{{/hide_name}}
+            {{> deprecation}}
             {{#declaration}}
               <div class="declaration">
                 <div class="language">

--- a/lib/jazzy/themes/fullwidth/templates/task.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/task.mustache
@@ -20,7 +20,12 @@
         </code>
         {{/direct_link}}
         {{^direct_link}}
+        {{^usage_discouraged}}
         <a class="token" href="#/{{usr}}">{{name}}</a>
+        {{/usage_discouraged}}
+        {{#usage_discouraged}}
+        <a class="token" href="#/{{usr}}"><strike>{{name}}</strike></a>
+        {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}
           <span class="declaration-note">
@@ -37,6 +42,18 @@
         <div class="pointer-container"></div>
         <section class="section">
           <div class="pointer"></div>
+          {{#deprecation_message}}
+          <div class="aside">
+            <p class="aside-title">Deprecated</p>
+            {{{deprecation_message}}}
+          </div>
+          {{/deprecation_message}}
+          {{#unavailable_message}}
+          <div class="aside">
+            <p class="aside-title">Unavailable</p>
+            {{{unavailable_message}}}
+          </div>
+          {{/unavailable_message}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}

--- a/lib/jazzy/themes/fullwidth/templates/task.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/task.mustache
@@ -42,18 +42,7 @@
         <div class="pointer-container"></div>
         <section class="section">
           <div class="pointer"></div>
-          {{#deprecation_message}}
-          <div class="aside aside-deprecated">
-            <p class="aside-title">Deprecated</p>
-            {{{deprecation_message}}}
-          </div>
-          {{/deprecation_message}}
-          {{#unavailable_message}}
-          <div class="aside aside-unavailable">
-            <p class="aside-title">Unavailable</p>
-            {{{unavailable_message}}}
-          </div>
-          {{/unavailable_message}}
+          {{> deprecation}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}

--- a/lib/jazzy/themes/fullwidth/templates/task.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/task.mustache
@@ -24,7 +24,7 @@
         <a class="token" href="#/{{usr}}">{{name}}</a>
         {{/usage_discouraged}}
         {{#usage_discouraged}}
-        <a class="token" href="#/{{usr}}"><strike>{{name}}</strike></a>
+        <a class="token discouraged" href="#/{{usr}}">{{name}}</a>
         {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}

--- a/lib/jazzy/themes/fullwidth/templates/task.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/task.mustache
@@ -43,13 +43,13 @@
         <section class="section">
           <div class="pointer"></div>
           {{#deprecation_message}}
-          <div class="aside">
+          <div class="aside aside-deprecated">
             <p class="aside-title">Deprecated</p>
             {{{deprecation_message}}}
           </div>
           {{/deprecation_message}}
           {{#unavailable_message}}
-          <div class="aside">
+          <div class="aside aside-unavailable">
             <p class="aside-title">Unavailable</p>
             {{{unavailable_message}}}
           </div>

--- a/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
@@ -448,7 +448,7 @@ header {
   }
 }
 
-.aside-warning {
+.aside-warning, .aside-deprecated, .aside-unavailable {
   border-left: $aside_warning_border;
   .aside-title {
     color: $aside_warning_color;

--- a/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
@@ -376,6 +376,9 @@ header {
     padding-left: 3px;
     margin-left: 35px;
   }
+  .discouraged {
+    text-decoration: line-through;
+  }
   .declaration-note {
     font-size: .85em;
     color: rgba(128,128,128,1);

--- a/lib/jazzy/themes/jony/templates/deprecation.mustache
+++ b/lib/jazzy/themes/jony/templates/deprecation.mustache
@@ -1,0 +1,12 @@
+{{#deprecation_message}}
+<div class="aside aside-deprecated">
+  <p class="aside-title">Deprecated</p>
+  {{{deprecation_message}}}
+</div>
+{{/deprecation_message}}
+{{#unavailable_message}}
+<div class="aside aside-unavailable">
+  <p class="aside-title">Unavailable</p>
+  {{{unavailable_message}}}
+</div>
+{{/unavailable_message}}

--- a/lib/jazzy/themes/jony/templates/doc.mustache
+++ b/lib/jazzy/themes/jony/templates/doc.mustache
@@ -33,6 +33,7 @@
           <section>
             <section class="section">
               {{^hide_name}}<h1>{{name}}</h1>{{/hide_name}}
+              {{> deprecation}}
               {{#declaration}}
                 <div class="declaration">
                   <div class="language">

--- a/lib/jazzy/themes/jony/templates/task.mustache
+++ b/lib/jazzy/themes/jony/templates/task.mustache
@@ -20,7 +20,12 @@
         </code>
         {{/direct_link}}
         {{^direct_link}}
+        {{^usage_discouraged}}
         <a class="token" href="#/{{usr}}">{{name}}</a>
+        {{/usage_discouraged}}
+        {{#usage_discouraged}}
+        <a class="token" href="#/{{usr}}"><strike>{{name}}</strike></a>
+        {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}
           <span class="declaration-note">
@@ -37,6 +42,18 @@
         <div class="pointer-container"></div>
         <section class="section">
           <div class="pointer"></div>
+          {{#deprecation_message}}
+          <div class="aside">
+            <p class="aside-title">Deprecated</p>
+            {{{deprecation_message}}}
+          </div>
+          {{/deprecation_message}}
+          {{#unavailable_message}}
+          <div class="aside">
+            <p class="aside-title">Unavailable</p>
+            {{{unavailable_message}}}
+          </div>
+          {{/unavailable_message}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}

--- a/lib/jazzy/themes/jony/templates/task.mustache
+++ b/lib/jazzy/themes/jony/templates/task.mustache
@@ -42,18 +42,7 @@
         <div class="pointer-container"></div>
         <section class="section">
           <div class="pointer"></div>
-          {{#deprecation_message}}
-          <div class="aside aside-deprecated">
-            <p class="aside-title">Deprecated</p>
-            {{{deprecation_message}}}
-          </div>
-          {{/deprecation_message}}
-          {{#unavailable_message}}
-          <div class="aside aside-unavailable">
-            <p class="aside-title">Unavailable</p>
-            {{{unavailable_message}}}
-          </div>
-          {{/unavailable_message}}
+          {{> deprecation}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}

--- a/lib/jazzy/themes/jony/templates/task.mustache
+++ b/lib/jazzy/themes/jony/templates/task.mustache
@@ -24,7 +24,7 @@
         <a class="token" href="#/{{usr}}">{{name}}</a>
         {{/usage_discouraged}}
         {{#usage_discouraged}}
-        <a class="token" href="#/{{usr}}"><strike>{{name}}</strike></a>
+        <a class="token discouraged" href="#/{{usr}}">{{name}}</a>
         {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}

--- a/lib/jazzy/themes/jony/templates/task.mustache
+++ b/lib/jazzy/themes/jony/templates/task.mustache
@@ -43,13 +43,13 @@
         <section class="section">
           <div class="pointer"></div>
           {{#deprecation_message}}
-          <div class="aside">
+          <div class="aside aside-deprecated">
             <p class="aside-title">Deprecated</p>
             {{{deprecation_message}}}
           </div>
           {{/deprecation_message}}
           {{#unavailable_message}}
-          <div class="aside">
+          <div class="aside aside-unavailable">
             <p class="aside-title">Unavailable</p>
             {{{unavailable_message}}}
           </div>


### PR DESCRIPTION
Continuing #998.

Additions to the great original patch:
1. Move styling to CSS + color callouts following warning (red!).
2. Add deprecation notice to type page as well as index -- so if you deprecate a class then its page shows the notice.
4. Couple more tests + refactors for rubocop.

Index page, no message supplied:
<img width="393" alt="screenshot 2019-01-22 at 13 53 17" src="https://user-images.githubusercontent.com/26768470/51540734-14b27480-1e4f-11e9-87df-c9e5c640788e.png">

Index page, with message:
<img width="338" alt="screenshot 2019-01-22 at 13 51 33" src="https://user-images.githubusercontent.com/26768470/51540737-1714ce80-1e4f-11e9-8999-a8578ab0b7ac.png">

Type page:
<img width="383" alt="screenshot 2019-01-22 at 13 51 45" src="https://user-images.githubusercontent.com/26768470/51540743-18de9200-1e4f-11e9-81ba-e331beb560f6.png">
(I decided not to strike-through the page title because it looked weird and the notice is right there...)

@steviki could you take a look if you're still in this area -- I know it's been a long time!
A lot of the changed lines + files are duplicating changes among the themes.