### PR TITLE
Update integration spec projects

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -75,13 +75,14 @@ begin
 
     # Remove files not used for the comparison
     # To keep the git diff clean
-    files_glob = 'spec/integration_specs/*/after/{*,.*}'
+    specs_root = 'spec/integration_specs/*/after'
+    files_glob = "#{specs_root}/{*,.*}"
     files_to_delete = FileList[files_glob]
       .exclude('**/.', '**/..')
-      .exclude('spec/integration_specs/*/after/*docs',
-               'spec/integration_specs/*/after/execution_output.txt')
-      .include('**/*.dsidx')
-      .include('**/*.tgz')
+      .exclude("#{specs_root}/*docs",
+               "#{specs_root}/execution_output.txt")
+      .include("#{specs_root}/**/*.dsidx")
+      .include("#{specs_root}/**/*.tgz")
     files_to_delete.each do |file_to_delete|
       sh "rm -rf '#{file_to_delete}'"
     end

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -139,11 +139,9 @@ module Jazzy
           ss.available_platforms.each do |p|
             # Travis builds take too long when building docs for all available
             # platforms for the Moya integration spec, so we just document OSX.
-            # Also Moya's RxSwift subspec doesn't yet support Swift 4, so skip
-            # that too while we're at it.
             # TODO: remove once jazzy is fast enough.
             if ENV['JAZZY_INTEGRATION_SPECS']
-              next if (p.name != :osx) || (ss.name == 'Moya/RxSwift')
+              next if p.name != :osx
             end
             target("Jazzy-#{ss.name.gsub('/', '__')}-#{p.name}") do
               use_frameworks!

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -173,16 +173,9 @@ describe_cli 'jazzy' do
     describe 'Creates docs with a module name, author name, project URL, ' \
       'xcodebuild options, and github info' do
       behaves_like cli_spec 'document_alamofire',
-                            '-m Alamofire -a Alamofire ' \
-                            '-u https://nshipster.com/alamofire ' \
-                            '-x -project,Alamofire.xcodeproj ' \
-                            '-g https://github.com/Alamofire/Alamofire ' \
-                            '--github-file-prefix https://github.com/' \
-                            'Alamofire/Alamofire/blob/4.3.0 ' \
-                            '--module-version 4.3.0 ' \
-                            '--root-url ' \
-                            'https://static.realm.io/jazzy_demo/Alamofire/ ' \
-                            '--skip-undocumented'
+                            '--skip-undocumented',
+                            # Ignore existing docs output
+                            '--clean'
     end
 
     describe 'Creates Realm Swift docs' do


### PR DESCRIPTION
Towards Swift 5 support: break most dependencies on Swift 3, update recipes.
RealmSwift latest still uses Swift 3 mode for its docs generation.
