### PR TITLE
"Other" category prefix

### DIFF
--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -62,9 +62,7 @@ module Jazzy
     # Group root-level docs by custom categories (if any) and type
     def self.group_docs(docs)
       custom_categories, docs = group_custom_categories(docs)
-      type_categories, uncategorized = group_type_categories(
-        docs, custom_categories.any? ? 'Other ' : ''
-      )
+      type_categories, uncategorized = group_type_categories(docs)
       custom_categories + type_categories + uncategorized
     end
 
@@ -85,14 +83,14 @@ module Jazzy
       [group.compact, docs]
     end
 
-    def self.group_type_categories(docs, type_category_prefix)
+    def self.group_type_categories(docs)
       group = SourceDeclaration::Type.all.map do |type|
         children, docs = docs.partition { |doc| doc.type == type }
         make_group(
           children,
-          type_category_prefix + type.plural_name,
+          type.plural_name,
           "The following #{type.plural_name.downcase} are available globally.",
-          type_category_prefix + type.plural_url_name,
+          type.plural_url_name,
         )
       end
       [group.compact, docs]


### PR DESCRIPTION
Since there has not been any discussion in issue #552 for quite some time, I am making this obviously incomplete PR to encourage that we discuss this again. I can finish the rest when we decide exactly what to do about this issue.

Related PR: https://github.com/realm/jazzy-integration-specs/pull/78

Please note that I have just started using jazzy and I am unfamiliar with how it should work, potential side effects, etc.

Removing the "Other" category prefix works best for me both when using custom categories and when not using them. I do not see any reasons why I would name any custom categories so that I end up with duplicate names, and I do not see any reason why I would want "Other" in the name without explicitly naming a category that way myself.

Therefore I cannot currently see any reasons to keep this prefix, but I guess it is not as simple as just removing it completely, as I am sure there was a good reason for this.

What do you think?

Note: Uses a custom branch of `jazzy-integration-specs`.