### PR TITLE
Fix section open when linked to from current page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Unfold member documentation when linked to from current web page.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#788](https://github.com/realm/jazzy/issues/788)
 
 ## 0.9.6
 

--- a/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
@@ -337,6 +337,10 @@ header {
     padding-left: 3px;
     margin-left: 15px;
     font-size: 11.9px;
+    transition: all 300ms;
+  }
+  .token-open {
+    margin-left: 0px;
   }
   .discouraged {
     text-decoration: line-through;

--- a/lib/jazzy/themes/apple/assets/js/jazzy.js
+++ b/lib/jazzy/themes/apple/assets/js/jazzy.js
@@ -8,33 +8,52 @@ if (navigator.userAgent.match(/xcode/i)) {
   window.jazzy.docset = true
 }
 
-// On doc load, toggle the URL hash discussion if present
-$(document).ready(function() {
-  if (!window.jazzy.docset) {
-    var linkToHash = $('a[href="' + window.location.hash +'"]');
-    linkToHash.trigger("click");
-  }
-});
+function toggleItem($link, $content) {
+  var animationDuration = 300;
+  $link.toggleClass('token-open');
+  $content.slideToggle(animationDuration);
+}
 
-// On token click, toggle its discussion and animate token.marginLeft
-$(".token").click(function(event) {
+function itemLinkToContent($link) {
+  return $link.parent().parent().next();
+}
+
+// On doc load + hash-change, open any targetted item
+function openCurrentItemIfClosed() {
   if (window.jazzy.docset) {
     return;
   }
-  var link = $(this);
-  var animationDuration = 300;
-  var tokenOffset = "15px";
-  var original = link.css('marginLeft') == tokenOffset;
-  link.animate({'margin-left':original ? "0px" : tokenOffset}, animationDuration);
-  $content = link.parent().parent().next();
-  $content.slideToggle(animationDuration);
+  var $link = $(`.token[href="${location.hash}"]`);
+  $content = itemLinkToContent($link);
+  if ($content.is(':hidden')) {
+    toggleItem($link, $content);
+  }
+}
+
+$(openCurrentItemIfClosed);
+$(window).on('hashchange', openCurrentItemIfClosed);
+
+// On item link ('token') click, toggle its discussion
+$('.token').on('click', function(event) {
+  if (window.jazzy.docset) {
+    return;
+  }
+  var $link = $(this);
+  toggleItem($link, itemLinkToContent($link));
 
   // Keeps the document from jumping to the hash.
-  var href = $(this).attr('href');
+  var href = $link.attr('href');
   if (history.pushState) {
     history.pushState({}, '', href);
   } else {
     location.hash = href;
   }
   event.preventDefault();
+});
+
+// Clicks on links to the current, closed, item need to open the item
+$("a:not('.token')").on('click', function() {
+  if (location == this.href) {
+    openCurrentItemIfClosed();
+  }
 });

--- a/lib/jazzy/themes/fullwidth/assets/js/jazzy.js
+++ b/lib/jazzy/themes/fullwidth/assets/js/jazzy.js
@@ -8,30 +8,52 @@ if (navigator.userAgent.match(/xcode/i)) {
   window.jazzy.docset = true
 }
 
-// On doc load, toggle the URL hash discussion if present
-$(document).ready(function() {
-  if (!window.jazzy.docset) {
-    var linkToHash = $('a[href="' + window.location.hash +'"]');
-    linkToHash.trigger("click");
-  }
-});
+function toggleItem($link, $content) {
+  var animationDuration = 300;
+  $link.toggleClass('token-open');
+  $content.slideToggle(animationDuration);
+}
 
-// On token click, toggle its discussion and animate token.marginLeft
-$(".token").click(function(event) {
+function itemLinkToContent($link) {
+  return $link.parent().parent().next();
+}
+
+// On doc load + hash-change, open any targetted item
+function openCurrentItemIfClosed() {
   if (window.jazzy.docset) {
     return;
   }
-  var link = $(this);
-  var animationDuration = 300;
-  $content = link.parent().parent().next();
-  $content.slideToggle(animationDuration);
+  var $link = $(`.token[href="${location.hash}"]`);
+  $content = itemLinkToContent($link);
+  if ($content.is(':hidden')) {
+    toggleItem($link, $content);
+  }
+}
+
+$(openCurrentItemIfClosed);
+$(window).on('hashchange', openCurrentItemIfClosed);
+
+// On item link ('token') click, toggle its discussion
+$('.token').on('click', function(event) {
+  if (window.jazzy.docset) {
+    return;
+  }
+  var $link = $(this);
+  toggleItem($link, itemLinkToContent($link));
 
   // Keeps the document from jumping to the hash.
-  var href = $(this).attr('href');
+  var href = $link.attr('href');
   if (history.pushState) {
     history.pushState({}, '', href);
   } else {
     location.hash = href;
   }
   event.preventDefault();
+});
+
+// Clicks on links to the current, closed, item need to open the item
+$("a:not('.token')").on('click', function() {
+  if (location == this.href) {
+    openCurrentItemIfClosed();
+  }
 });

--- a/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
@@ -375,9 +375,13 @@ header {
   .token, .direct-link {
     padding-left: 3px;
     margin-left: 35px;
+    transition: all 300ms;
   }
   .discouraged {
     text-decoration: line-through;
+  }
+  .token-open {
+    margin-left: 25px;
   }
   .declaration-note {
     font-size: .85em;

--- a/lib/jazzy/themes/jony/assets/js/jazzy.js
+++ b/lib/jazzy/themes/jony/assets/js/jazzy.js
@@ -8,34 +8,52 @@ if (navigator.userAgent.match(/xcode/i)) {
   window.jazzy.docset = true
 }
 
-// On doc load, toggle the URL hash discussion if present
-$(document).ready(function() {
-  if (!window.jazzy.docset) {
-    var linkToHash = $('a[href="' + window.location.hash +'"]');
-    linkToHash.trigger("click");
-  }
-});
+function toggleItem($link, $content) {
+  var animationDuration = 300;
+  $link.toggleClass('token-open');
+  $content.slideToggle(animationDuration);
+}
 
-// On token click, toggle its discussion and animate token.marginLeft
-$(".token").click(function(event) {
+function itemLinkToContent($link) {
+  return $link.parent().parent().next();
+}
+
+// On doc load + hash-change, open any targetted item
+function openCurrentItemIfClosed() {
   if (window.jazzy.docset) {
     return;
   }
-  var link = $(this);
-  var animationDuration = 300;
-  var tokenOffset = "35px";
-  var selectedOffset = "25px";
-  var original = link.css('marginLeft') == tokenOffset;
-  link.animate({'margin-left':original ? selectedOffset : tokenOffset}, animationDuration);
-  $content = link.parent().parent().next();
-  $content.slideToggle(animationDuration);
+  var $link = $(`.token[href="${location.hash}"]`);
+  $content = itemLinkToContent($link);
+  if ($content.is(':hidden')) {
+    toggleItem($link, $content);
+  }
+}
+
+$(openCurrentItemIfClosed);
+$(window).on('hashchange', openCurrentItemIfClosed);
+
+// On item link ('token') click, toggle its discussion
+$('.token').on('click', function(event) {
+  if (window.jazzy.docset) {
+    return;
+  }
+  var $link = $(this);
+  toggleItem($link, itemLinkToContent($link));
 
   // Keeps the document from jumping to the hash.
-  var href = $(this).attr('href');
+  var href = $link.attr('href');
   if (history.pushState) {
     history.pushState({}, '', href);
   } else {
     location.hash = href;
   }
   event.preventDefault();
+});
+
+// Clicks on links to the current, closed, item need to open the item
+$("a:not('.token')").on('click', function() {
+  if (location == this.href) {
+    openCurrentItemIfClosed();
+  }
 });


### PR DESCRIPTION
This is a javascript fix to navigation involving the openable/closable sections.

Main bug fixed is #788:
* Click to open section A.
* Click a link to section B on the same page.
* Before: scroll to B but B does not open; after: B opens.
   
Subtly different bug:
* Click to open section A.
* Click to close section A.
* Click a link to A.
* Before: scroll to A but nothing happens; after: A opens.
   
Also move a couple of things to CSS so that the `jazzy.js` file is 100% identical between the themes: 'changed lines' stat inflated by 3 copies of this.

Spec changes to reflect shipped js/css files.  Manually verified dash is still fine.
