### PR TITLE
Swift 5 updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
 
   swift:
     macos:
-      xcode: "10.0.0"
+      xcode: "10.2.0"
     environment: *bundler-environment
     # Used to invoke chruby
     shell: *shell
@@ -38,7 +38,7 @@ jobs:
 
   objc:
     macos:
-      xcode: "10.0.0"
+      xcode: "10.2.0"
     environment: *bundler-environment
     # Used to invoke chruby
     shell: *shell
@@ -53,7 +53,7 @@ jobs:
 
   cocoapods:
     macos:
-      xcode: "10.0.0"
+      xcode: "10.2.0"
     environment: *bundler-environment
     # Used to invoke chruby
     shell: *shell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ##### Enhancements
 
+* Swift 5 support: suppress unwanted newlines and `deinit` declarations.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 * Update JavaScript libraries: jQuery 3.3.1 (all themes), Lunr 2.3.5,
   typeahead.js 1.2.1 (`fullwidth` theme only).  
   [John Fairhurst](https://github.com/johnfairh)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 10.0 installed to build the integration specs.
+You must have Xcode 10.2 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -98,7 +98,7 @@ module Jazzy
     private_class_method :github_file_prefix
 
     # Latest valid value for SWIFT_VERSION.
-    LATEST_SWIFT_VERSION = '4.2'.freeze
+    LATEST_SWIFT_VERSION = '5'.freeze
 
     # All valid values for SWIFT_VERSION that are longer
     # than a major version number.  Ordered ascending.

--- a/lib/jazzy/source_declaration/access_control_level.rb
+++ b/lib/jazzy/source_declaration/access_control_level.rb
@@ -26,6 +26,8 @@ module Jazzy
       end
 
       def self.from_doc(doc)
+        return AccessControlLevel.internal if implicit_deinit?(doc)
+
         accessibility = doc['key.accessibility']
         if accessibility
           acl = new(accessibility)
@@ -33,12 +35,17 @@ module Jazzy
             return acl
           end
         end
-        acl = from_explicit_declaration(doc['key.parsed_declaration'])
+        acl = from_doc_explicit_declaration(doc)
         acl || AccessControlLevel.public # fallback on public ACL
       end
 
-      def self.from_explicit_declaration(declaration_string)
-        case declaration_string
+      def self.implicit_deinit?(doc)
+        doc['key.name'] == 'deinit' &&
+          from_doc_explicit_declaration(doc).nil?
+      end
+
+      def self.from_doc_explicit_declaration(doc)
+        case doc['key.parsed_declaration']
         when /private\ / then private
         when /fileprivate\ / then fileprivate
         when /public\ / then public

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -420,7 +420,9 @@ module Jazzy
           parsed_decl_body.unindent(inline_attrs.length)
         else
           # Strip ugly references to decl type name
-          unqualify_name(annotated_decl_body, declaration)
+          unqualified = unqualify_name(annotated_decl_body, declaration)
+          # Workaround for SR-9816
+          unqualified.gsub(" {\n  get\n  }", '')
         end
 
       # @available attrs only in compiler 'interface' style


### PR DESCRIPTION
Version number updates and a couple of compiler bug/feature workarounds.

SourceKit's calculation of accessibility has changed in Swift 5: internally it
now uses what the core compiler calculates rather than making it up
independently.  This may have knock-ons for some docsets.

Xcode 10.2 spec changes:

* Alamofire - nothing.
* Moya - some changes to printing of generic decls.
* Realm-ObjC - Decl printing changes, libclang updates in this Xcode!
* Realm-Swift - mostly somewhat ugly churn triggered by compiler changes in how SourceKit handles `#if` conditional compilation.  Will need to do something thoughtful about this but not right now.  Some generic decl printing changes.
* Siesta - whitespace decl-printing change.
* MiscJazzyFeatures - stdlib change knock-ons for an extension.
* MiscJazzyObjCFeatures - nothing.