### PR TITLE
Mustache templates can now expose `{{module_version}}`

### DIFF
--- a/lib/jazzy/doc.rb
+++ b/lib/jazzy/doc.rb
@@ -38,5 +38,9 @@ module Jazzy
     def language_stub
       objc_first? ? 'objc' : 'swift'
     end
+
+    def module_version
+      Config.instance.version
+    end
   end
 end

--- a/lib/jazzy/themes/apple/templates/header.mustache
+++ b/lib/jazzy/themes/apple/templates/header.mustache
@@ -1,6 +1,6 @@
 <header>
   <div class="content-wrapper">
-    <p><a href="{{path_to_root}}index.html">{{module_name}} Docs</a>{{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}</p>
+    <p><a href="{{path_to_root}}index.html">{{module_name}} version {{module_version}} Docs</a>{{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}</p>
     {{#github_url}}
     <p class="header-right"><a href="{{github_url}}"><img src="{{path_to_root}}img/gh.png"/>View on GitHub</a></p>
     {{/github_url}}

--- a/lib/jazzy/themes/fullwidth/templates/header.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/header.mustache
@@ -1,7 +1,7 @@
 <header class="header">
   <p class="header-col header-col--primary">
     <a class="header-link" href="{{path_to_root}}index.html">
-      {{module_name}} Docs
+      {{module_name}} version {{module_version}} Docs
     </a>
     {{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}
   </p>

--- a/lib/jazzy/themes/jony/templates/header.mustache
+++ b/lib/jazzy/themes/jony/templates/header.mustache
@@ -1,7 +1,7 @@
 <header>
   <div class="content-wrapper">
     <p>
-      <a href="{{path_to_root}}index.html">{{module_name}} Docs</a>
+      <a href="{{path_to_root}}index.html">{{module_name}} version {{module_version}} Docs</a>
       <span class="no-mobile">{{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}</span>
     </p>
 


### PR DESCRIPTION
- I added module_version to expose `Config.instance.version`
- This can now expose `{{module_version}}` in the mustache templates. 

#810 #666 ##1064