### PR TITLE
Documentation title customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@
 * Show the extension declaration when documenting Swift extensions.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Allow docs title customization.  Include `--module-version` when it is set
+  and support `--title` to fully customize the title.  Pass `{{module_version}}`
+  and `{{docs_title}}` to templates.  
+  [Maximilian Alexander](https://github.com/mbalex99)
+  [John Fairhurst](https://github.com/johnfairh)
+  [#666](https://github.com/realm/jazzy/issues/666)
+  [#411](https://github.com/realm/jazzy/issues/411)
+
 ##### Bug Fixes
 
 * Unfold member documentation when linked to from current web page.  

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -2,7 +2,6 @@ require 'optparse'
 require 'pathname'
 require 'uri'
 
-require 'jazzy/doc'
 require 'jazzy/podspec_documenter'
 require 'jazzy/source_declaration/access_control_level'
 
@@ -213,8 +212,15 @@ module Jazzy
 
     config_attr :version,
       command_line: '--module-version VERSION',
-      description: 'module version. will be used when generating docset',
+      description: 'Version string to use as part of the the default docs '\
+                   'title and inside the docset.',
       default: '1.0'
+
+    config_attr :title,
+      command_line: '--title TITLE',
+      description: 'Title to display at the top of each page, overriding the '\
+                   'default generated from module name and version.',
+      default: ''
 
     config_attr :copyright,
       command_line: '--copyright COPYRIGHT_MARKDOWN',

--- a/lib/jazzy/doc.rb
+++ b/lib/jazzy/doc.rb
@@ -8,10 +8,11 @@ require 'jazzy/jazzy_markdown'
 
 module Jazzy
   class Doc < Mustache
+    include Config::Mixin
+
     self.template_name = 'doc'
 
     def copyright
-      config = Config.instance
       copyright = config.copyright || (
         # Fake date is used to keep integration tests consistent
         date = ENV['JAZZY_FAKE_DATE'] || DateTime.now.strftime('%Y-%m-%d')
@@ -28,7 +29,7 @@ module Jazzy
     end
 
     def objc_first?
-      Config.instance.objc_mode && Config.instance.hide_declarations != 'objc'
+      config.objc_mode && config.hide_declarations != 'objc'
     end
 
     def language
@@ -40,7 +41,19 @@ module Jazzy
     end
 
     def module_version
-      Config.instance.version
+      config.version_configured ? config.version : nil
+    end
+
+    def docs_title
+      if config.title_configured
+        config.title
+      elsif config.version_configured
+        # Fake version for integration tests
+        version = ENV['JAZZY_FAKE_MODULE_VERSION'] || config.version
+        "#{config.module_name} #{version} Docs"
+      else
+        "#{config.module_name} Docs"
+      end
     end
   end
 end

--- a/lib/jazzy/doc.rb
+++ b/lib/jazzy/doc.rb
@@ -38,5 +38,9 @@ module Jazzy
     def language_stub
       objc_first? ? 'objc' : 'swift'
     end
+
+    def module_version
+      Config.instance.version
+    end
   end
 end

--- a/lib/jazzy/themes/apple/templates/header.mustache
+++ b/lib/jazzy/themes/apple/templates/header.mustache
@@ -1,6 +1,6 @@
 <header>
   <div class="content-wrapper">
-    <p><a href="{{path_to_root}}index.html">{{module_name}} Docs</a>{{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}</p>
+    <p><a href="{{path_to_root}}index.html">{{module_name}} version {{module_version}} Docs</a>{{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}</p>
     {{#github_url}}
     <p class="header-right"><a href="{{github_url}}"><img src="{{path_to_root}}img/gh.png"/>View on GitHub</a></p>
     {{/github_url}}

--- a/lib/jazzy/themes/apple/templates/header.mustache
+++ b/lib/jazzy/themes/apple/templates/header.mustache
@@ -1,6 +1,6 @@
 <header>
   <div class="content-wrapper">
-    <p><a href="{{path_to_root}}index.html">{{module_name}} version {{module_version}} Docs</a>{{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}</p>
+    <p><a href="{{path_to_root}}index.html">{{docs_title}}</a>{{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}</p>
     {{#github_url}}
     <p class="header-right"><a href="{{github_url}}"><img src="{{path_to_root}}img/gh.png"/>View on GitHub</a></p>
     {{/github_url}}

--- a/lib/jazzy/themes/fullwidth/templates/header.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/header.mustache
@@ -1,7 +1,7 @@
 <header class="header">
   <p class="header-col header-col--primary">
     <a class="header-link" href="{{path_to_root}}index.html">
-      {{module_name}} Docs
+      {{module_name}} version {{module_version}} Docs
     </a>
     {{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}
   </p>

--- a/lib/jazzy/themes/fullwidth/templates/header.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/header.mustache
@@ -1,7 +1,7 @@
 <header class="header">
   <p class="header-col header-col--primary">
     <a class="header-link" href="{{path_to_root}}index.html">
-      {{module_name}} version {{module_version}} Docs
+      {{docs_title}}
     </a>
     {{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}
   </p>

--- a/lib/jazzy/themes/jony/templates/header.mustache
+++ b/lib/jazzy/themes/jony/templates/header.mustache
@@ -1,7 +1,7 @@
 <header>
   <div class="content-wrapper">
     <p>
-      <a href="{{path_to_root}}index.html">{{module_name}} Docs</a>
+      <a href="{{path_to_root}}index.html">{{module_name}} version {{module_version}} Docs</a>
       <span class="no-mobile">{{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}</span>
     </p>
 

--- a/lib/jazzy/themes/jony/templates/header.mustache
+++ b/lib/jazzy/themes/jony/templates/header.mustache
@@ -1,7 +1,7 @@
 <header>
   <div class="content-wrapper">
     <p>
-      <a href="{{path_to_root}}index.html">{{module_name}} version {{module_version}} Docs</a>
+      <a href="{{path_to_root}}index.html">{{docs_title}}</a>
       <span class="no-mobile">{{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}</span>
     </p>
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -103,6 +103,7 @@ describe_cli 'jazzy' do
       'JAZZY_FAKE_VERSION'         => 'X.X.X',
       'COCOAPODS_SKIP_UPDATE_MESSAGE' => 'TRUE',
       'JAZZY_INTEGRATION_SPECS' => 'TRUE',
+      'JAZZY_FAKE_MODULE_VERSION' => 'Y.Y.Y',
     }
     s.default_args = []
     s.replace_path ROOT.to_s, 'ROOT'


### PR DESCRIPTION
Continuing #1065.

This adds the module version number to the docs title if one is configured, and also adds a `--title` flag to let users completely customise the docs title.

In the various themes:
<img width="253" alt="Screenshot 2019-06-19 at 14 31 07" src="https://user-images.githubusercontent.com/26768470/59778063-acf14000-92ad-11e9-896b-310e3f9b47fd.png">

<img width="265" alt="Screenshot 2019-06-19 at 14 30 03" src="https://user-images.githubusercontent.com/26768470/59778064-ad89d680-92ad-11e9-8de4-400066897c40.png">

<img width="499" alt="Screenshot 2019-06-19 at 14 30 26" src="https://user-images.githubusercontent.com/26768470/59778065-ad89d680-92ad-11e9-9b00-fee4f7eb4cb1.png">


Specs changes to show results of various options.