### PR TITLE
Preserve non-latin characters in guide filenames and heading IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Preserve non-latin characters in guide filenames and heading IDs.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1091](https://github.com/realm/jazzy/issues/1091)
 
 ## 0.10.0
 

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -11,7 +11,7 @@ module Jazzy
       attr_accessor :default_language
 
       def header(text, header_level)
-        text_slug = text.gsub(/[^\w]+/, '-')
+        text_slug = text.gsub(/[^[[:word:]]]+/, '-')
                         .downcase
                         .sub(/^-/, '')
                         .sub(/-$/, '')

--- a/lib/jazzy/source_document.rb
+++ b/lib/jazzy/source_document.rb
@@ -37,7 +37,7 @@ module Jazzy
     end
 
     def url
-      name.downcase.strip.tr(' ', '-').gsub(/[^\w-]/, '') + '.html'
+      name.downcase.strip.tr(' ', '-').gsub(/[^[[:word:]]-]/, '') + '.html'
     end
 
     def content(source_module)


### PR DESCRIPTION
Fixes #1091.

Jazzy is too aggressive at stripping out 'bad' characters when making 'friendly' identifiers.  This is a simple change that uses a unicode-friendly 'letter' definition.  We did this in another place too - when generating href IDs for markdown headings.

Added a demo of these to the sample project.