### PR TITLE
Escape URLs in href attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#1091](https://github.com/realm/jazzy/issues/1091)
 
+* Generate correct html for custom categories containing special
+  characters.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#945](https://github.com/realm/jazzy/issues/945)
+
 ## 0.10.0
 
 ##### Breaking

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -95,10 +95,9 @@ module Jazzy
     def self.each_doc(output_dir, docs, &block)
       docs.each do |doc|
         next unless doc.render_as_page?
-        # Assuming URL is relative to documentation root:
-        path = output_dir + (doc.url || "#{doc.name}.html")
+        # Filepath is relative to documentation root:
+        path = output_dir + doc.filepath
         block.call(doc, path)
-        next if doc.name == 'index'
         each_doc(
           output_dir,
           doc.children,

--- a/lib/jazzy/docset_builder.rb
+++ b/lib/jazzy/docset_builder.rb
@@ -78,7 +78,7 @@ module Jazzy
             'searchIndex (name, type, path);')
           source_module.all_declarations.select(&:type).each do |doc|
             db.execute('INSERT OR IGNORE INTO searchIndex(name, type, path) ' \
-              'VALUES (?, ?, ?);', [doc.name, doc.type.dash_type, doc.url])
+              'VALUES (?, ?, ?);', [doc.name, doc.type.dash_type, doc.filepath])
           end
         end
       end

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -111,6 +111,10 @@ module Jazzy
       unavailable || deprecated
     end
 
+    def filepath
+      CGI.unescape(url)
+    end
+
     def alternative_abstract
       if file = alternative_abstract_file
         Pathname(file).read

--- a/lib/jazzy/source_document.rb
+++ b/lib/jazzy/source_document.rb
@@ -20,6 +20,7 @@ module Jazzy
     def self.make_index(readme_path)
       SourceDocument.new.tap do |sd|
         sd.name = 'index'
+        sd.url = sd.name + '.html'
         sd.readme_path = readme_path
       end
     end
@@ -36,8 +37,8 @@ module Jazzy
       Config.instance
     end
 
-    def url
-      name.downcase.strip.tr(' ', '-').gsub(/[^[[:word:]]-]/, '') + '.html'
+    def url_name
+      name.downcase.strip.tr(' ', '-').gsub(/[^[[:word:]]-]/, '')
     end
 
     def content(source_module)


### PR DESCRIPTION
This does URL-escaping (%-encoding) for href attributes in the generated html.
We get away without doing this most of the time, #945 shows when we do not.

Pervasive spec changes to deal with files that contain spaces and () (objc), plus added a test to include the 945 case.