### PR TITLE
Use xcodebuild in more cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ##### Bug Fixes
 
-* None.
+* Don't use SwiftPM if there is an Xcode workspace or project in a non-root
+  directory.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1103](https://github.com/realm/jazzy/issues/1103)
 
 ## 0.11.0
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ unacceptable behavior to [info@realm.io](mailto:info@realm.io).
 
 ## Requirements
 
-* Development tools that can build the project you wish to document.  Jazzy supports
-  both [Xcode][xcode] and [Swift Package Manager][spm] projects.
+You need development tools to build the project you wish to document.  Jazzy supports
+both [Xcode][xcode] and [Swift Package Manager][spm] projects.
+
+Jazzy expects to be running on __macOS__.  See [below](#linux) for tips to run Jazzy
+on Linux.
 
 ## Installation
 
@@ -241,6 +244,24 @@ For example to use Xcode 9.4:
 ```shell
 jazzy --swift-version 4.1.2
 ```
+
+## Linux
+
+Jazzy uses [SourceKitten][sourcekitten] to communicate with the Swift build
+environment and compiler.  The `sourcekitten` binary included in the Jazzy gem
+is built for macOS and so does not run on other operating systems.
+
+To use Jazzy on Linux you first need to install and build `sourcekitten`
+following instructions from [SourceKitten's GitHub repository][sourcekitten].
+
+Then to generate documentation for a SwiftPM project, instead of running just
+`jazzy` do:
+```shell
+sourcekitten doc --spm > doc.json
+jazzy --sourcekitten-sourcefile doc.json
+```
+
+We hope to improve this process in the future.
 
 ## Troubleshooting
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -185,7 +185,9 @@ module Jazzy
     def self.use_spm?(options)
       options.swift_build_tool == :spm ||
         (!options.swift_build_tool_configured &&
-         Dir['*.xcodeproj'].empty?)
+         Dir['*.xcodeproj', '*.xcworkspace'].empty? &&
+         !options.build_tool_arguments.include?('-project') &&
+         !options.build_tool_arguments.include?('-workspace'))
     end
 
     # Builds SourceKitten arguments based on Jazzy options


### PR DESCRIPTION
Real world projects can have an xcworkspace without an xcproject at the same level, check for that and avoid using SPM.

Also check for the `xcodebuild` arguments that would be necessary if the project/workspace were in a different directory than the root.

Fixes #1103, recreated + verified against their project.