### PR TITLE
Make specs output stable with CocoaPods CDN

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -52,13 +52,9 @@ require 'cocoapods'
 
 def configure_cocoapods
   Pod::Config.instance.with_changes(silent: true) do
-    config = Pod::Config.instance
-    # working around a bug where `pod setup --silent` isn't silent
-    if config.sources_manager.master_repo_functional?
-      Pod::Command::Repo::Update.invoke(%w[master])
-    else
-      Pod::Command::Setup.invoke
-    end
+    Pod::Command::Setup.invoke
+    Pod::Command::Repo::AddCDN.invoke(%w[trunk https://cdn.cocoapods.org/])
+    Pod::Command::Repo::Update.invoke(%w[trunk])
   end
 end
 


### PR DESCRIPTION
The CDN being on by default in 1.8 makes the CLI output different depending on whether the CDN repo has been added at the start of the tests: if not there is an extra line of output and other bits of output _don't_ get colorized.

This patch moves the CDN repo setup out of the 'spec' part of the test so that `rake spec` works locally as well as in CI.

I think it's OK to assume cocoapods 1.8+ in the specs because of the Gemfile.lock version.