### PR TITLE
Handle Swift extensions of ObjC types in Mixed Project

### DIFF
--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -76,6 +76,12 @@ module Jazzy
       name.split(/[\(\)]/) if type.objc_category?
     end
 
+    def swift_extension_objc_name
+      return unless type.swift_extensible? || type.swift_extension?
+
+      usr.split("(cs)").last
+    end
+
     # The language in the templates for display
     def display_language
       return 'Swift' if swift?

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -584,8 +584,8 @@ module Jazzy
 
     # Two declarations get merged if they have the same deduplication key.
     def self.deduplication_key(decl, root_decls)
-      if decl.type.swift_extensible? || decl.type.swift_extension?
-        [decl.usr, decl.name]
+      if decl.type.swift_extension?
+        [decl.swift_extension_objc_name, :objc_class_and_categories]
       elsif mergeable_objc?(decl, root_decls)
         name, _ = decl.objc_category_name || decl.name
         [name, :objc_class_and_categories]


### PR DESCRIPTION
Still some work to do here:

1. Mixed docs should **not** have two tables of contents entries for classes. It seems like this is just a matter of combining passes and is probably an easy fix in the templating. Need to investigate more. If you look at the URL's namespace for `Classes` it contains all of the classes. They are just displaying incorrectly for navigation purposes.
 
2. Handle "nested" ObjC types. ex: 

	```
	NS_SWIFT_NAME(Foo.Bar)
	@interface FooBar
	```

	* When showing ObjC it should show up as top-level type (`FooBar`)
	
	* When showing Swift it should show up as nested type (
        
        ```
        Foo 
          -Bar
       ```

	* When showing mixed it should show up as a top-level type (`FooBar`)

3. Handle Swift extension on ObjC types
	
	*  When only Swift it should still deduplicate and treat it as one declaration - **Currently is showing up in separate class but likely will be fixed as part of item (1)**

	* When showing ObjC - n/a

	* When showing mixed - should deduplicate and treat it as a single declaration - **Works in this PR**

4. Swift extension on 'nested' ObjC types

	* Should work as described in (2) but include the methods from the extension.


5. Swift subclass of objc type

	* Should show up under classes as it's own type

6. Swift subclass of 'nested' objc type

	* Should show up under classes as it's own type


I think this is pretty comprehensive. Figured opening the PR early would be the best way to track the work.