### PR TITLE
Run CI on Catalina/Xcode 11.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,25 +12,16 @@ aliases:
     BUNDLE_RETRY: 3
     BUNDLE_PATH: vendor/bundle
 
-  - &shell
-    /bin/bash --login -eo pipefail
-
-  - &set-ruby-version
-    echo "ruby-2.4" > ~/.ruby-version
-
 version: 2
 jobs:
 
   swift:
     macos:
-      xcode: "10.2.0"
+      xcode: "11.2.0"
     environment: *bundler-environment
-    # Used to invoke chruby
-    shell: *shell
     steps:
       - checkout
       - restore_cache: *restore-mac-bundler-cache
-      - run: *set-ruby-version
       - run: bundle install
       - run: git submodule update --init --recursive
       - run: bundle exec rake swift_spec
@@ -38,14 +29,11 @@ jobs:
 
   objc:
     macos:
-      xcode: "10.2.0"
+      xcode: "11.2.0"
     environment: *bundler-environment
-    # Used to invoke chruby
-    shell: *shell
     steps:
       - checkout
       - restore_cache: *restore-mac-bundler-cache
-      - run: *set-ruby-version
       - run: bundle install
       - run: git submodule update --init --recursive
       - run: bundle exec rake objc_spec
@@ -53,16 +41,13 @@ jobs:
 
   cocoapods:
     macos:
-      xcode: "10.2.0"
+      xcode: "11.2.0"
     environment: *bundler-environment
-    # Used to invoke chruby
-    shell: *shell
     steps:
       - checkout
       - restore_cache:
           key: cocoapods
       - restore_cache: *restore-mac-bundler-cache
-      - run: *set-ruby-version
       - run: bundle install
       - run: git submodule update --init --recursive
       - run: bundle exec rake cocoapods_spec
@@ -76,8 +61,6 @@ jobs:
     docker:
       - image: circleci/ruby:2.4-node
         environment: *bundler-environment
-        # Used to invoke chruby
-        shell: *shell
     steps:
       - checkout
       - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Stop displaying type attributes on extension declarations.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ## 0.11.2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 10.2 installed to build the integration specs.
+You must have Xcode 11.2 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -408,8 +408,7 @@ module Jazzy
         parsed &&
           (annotated.include?(' = default') || # SR-2608
            parsed.match('@autoclosure|@escaping') || # SR-6321
-           parsed.include?("\n") ||
-           parsed.include?('extension '))
+           parsed.include?("\n"))
     end
 
     # Replace the fully qualified name of a type with its base name
@@ -430,6 +429,9 @@ module Jazzy
 
       # From source code
       parsed_decl = doc['key.parsed_declaration']
+
+      # Don't present type attributes on extensions
+      return parsed_decl if declaration.type.extension?
 
       decl =
         if prefer_parsed_decl?(parsed_decl, annotated_decl_body)


### PR DESCRIPTION
Try out circle's catalina image.  Use the system Ruby to run the specs.

Fix extension-related bug highlighted by Swift 5.1 (@frozen).

Just realised rubocop is pinned to 2017, should maybe update that.