### PR TITLE
Merge Swift and ObjC categories of the same kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Stop displaying type attributes on extension declarations.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Show ObjC and Swift classes (etc.) in the same category.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ## 0.11.2
 
 ##### Breaking

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -65,7 +65,7 @@ module Jazzy
       type_categories, uncategorized = group_type_categories(
         docs, custom_categories.any? ? 'Other ' : ''
       )
-      custom_categories + type_categories + uncategorized
+      custom_categories + merge_categories(type_categories) + uncategorized
     end
 
     def self.group_custom_categories(docs)
@@ -96,6 +96,19 @@ module Jazzy
         )
       end
       [group.compact, docs]
+    end
+
+    # Join categories with the same name (eg. ObjC and Swift classes)
+    def self.merge_categories(categories)
+      merged = []
+      categories.each do |new_category|
+        if existing = merged.find { |c| c.name == new_category.name }
+          existing.children += new_category.children
+        else
+          merged.append(new_category)
+        end
+      end
+      merged
     end
 
     def self.make_group(group, name, abstract, url_name = nil)


### PR DESCRIPTION
For mixed Swift and ObjC projects, generate merged 'classes' pages instead of generating two separate pages with the same name.

Spec project updates show the change:

<img width="412" alt="Screenshot 2019-11-06 at 12 32 01" src="https://user-images.githubusercontent.com/26768470/68298797-330df780-0092-11ea-8513-4695128b26cf.png">

I tried a couple of other clever data structure things but it turns out the order of the `TYPE` array determines the order in the site making it tough to not lose that, so, brute force.  The categories list is not very long.

@joesus can you take a look please?
