### PR TITLE
Deduplicate swift extension of objc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 * Show ObjC and Swift classes (etc.) in the same category.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Merge Swift extensions into ObjC classes.  
+  [John Fairhurst](https://github.com/johnfairh) [Joe Susnick](https://github.com/joesus)
+
 ## 0.11.2
 
 ##### Breaking

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -76,10 +76,14 @@ module Jazzy
       name.split(/[\(\)]/) if type.objc_category?
     end
 
-    def swift_extension_objc_name
-      return unless type.swift_extensible? || type.swift_extension?
+    def swift_objc_extension?
+      type.swift_extension? && usr && usr.start_with?('c:objc')
+    end
 
-      usr.split("(cs)").last
+    def swift_extension_objc_name
+      return unless type.swift_extension? && usr
+
+      usr.split('(cs)').last
     end
 
     # The language in the templates for display

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -76,6 +76,12 @@ module Jazzy
       name.split(/[\(\)]/) if type.objc_category?
     end
 
+    def swift_extension_objc_name
+      return unless type.swift_extensible? || type.swift_extension?
+
+      usr.split("(cs)").last
+    end
+
     # The language in the templates for display
     def display_language
       return 'Swift' if swift?

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -599,8 +599,8 @@ module Jazzy
 
     # Two declarations get merged if they have the same deduplication key.
     def self.deduplication_key(decl, root_decls)
-      if decl.type.swift_extensible? || decl.type.swift_extension?
-        [decl.usr, decl.name]
+      if decl.type.swift_extension?
+        [decl.swift_extension_objc_name, :objc_class_and_categories]
       elsif mergeable_objc?(decl, root_decls)
         name, _ = decl.objc_category_name || decl.name
         [name, :objc_class_and_categories]


### PR DESCRIPTION
This fixes mixed Swift-ObjC projects to correctly merge members from Swift extensions into their ObjC types.  Spec changes to show that working in the sample project.