### PR TITLE
Show conditional extensions in their own section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#447](https://github.com/realm/jazzy/issues/447)
 
+* Add section headings for members added by Swift conditional conformances.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#717](https://github.com/realm/jazzy/issues/717)
+
+* Parse markdown in MARK comments, make the html available to themes via
+  `name_html` mustache tag key for section headings.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ##### Bug Fixes
 
 * Stop displaying type attributes on extension declarations.  

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -350,9 +350,10 @@ module Jazzy
     end
     # rubocop:enable Metrics/MethodLength
 
-    def self.make_task(mark, uid, items)
+    def self.make_task(mark, uid, items, doc_model)
       {
         name: mark.name,
+        name_html: (render(doc_model, mark.name) if mark.name),
         uid: URI.encode(uid),
         items: items,
         pre_separator: mark.has_start_dash,
@@ -376,7 +377,7 @@ module Jazzy
         else
           mark_names_counts[uid] = 1
         end
-        make_task(mark, uid, items)
+        make_task(mark, uid, items, mark_children.first)
       end
     end
 

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -130,6 +130,7 @@ module Jazzy
     attr_accessor :deprecation_message
     attr_accessor :unavailable
     attr_accessor :unavailable_message
+    attr_accessor :generic_requirements
 
     def usage_discouraged?
       unavailable || deprecated
@@ -137,6 +138,19 @@ module Jazzy
 
     def filepath
       CGI.unescape(url)
+    end
+
+    def constrained_extension?
+      type.swift_extension? &&
+        generic_requirements
+    end
+
+    def mark_for_children
+      if constrained_extension?
+        SourceMark.new_generic_requirements(generic_requirements)
+      else
+        SourceMark.new
+      end
     end
 
     def alternative_abstract

--- a/lib/jazzy/source_mark.rb
+++ b/lib/jazzy/source_mark.rb
@@ -37,5 +37,10 @@ module Jazzy
       self.has_start_dash = other.has_start_dash
       self.has_end_dash = other.has_end_dash
     end
+
+    # Can we merge the contents of another mark into our own?
+    def can_merge?(other)
+      other.empty? || other.name == name
+    end
   end
 end

--- a/lib/jazzy/source_mark.rb
+++ b/lib/jazzy/source_mark.rb
@@ -28,6 +28,12 @@ module Jazzy
       self.name = mark_string[start_index..end_index]
     end
 
+    def self.new_generic_requirements(requirements)
+      marked_up = requirements.gsub(/\b([^=:]\S*)\b/, '`\1`')
+      text = "Available where #{marked_up}"
+      new(text)
+    end
+
     def empty?
       !name && !has_start_dash && !has_end_dash
     end

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -124,6 +124,18 @@ module Jazzy
       end
     end
 
+    # Merge consecutive sections with the same mark into one section
+    def self.merge_consecutive_marks(docs)
+      prev_mark = nil
+      docs.each do |doc|
+        if prev_mark && prev_mark.can_merge?(doc.mark)
+          doc.mark = prev_mark
+        end
+        prev_mark = doc.mark
+        merge_consecutive_marks(doc.children)
+      end
+    end
+
     def self.sanitize_filename(doc)
       unsafe_filename = doc.url_name || doc.name
       sanitzation_enabled = Config.instance.use_safe_filenames
@@ -870,6 +882,7 @@ module Jazzy
       docs = docs.reject { |doc| doc.type.swift_enum_element? }
       ungrouped_docs = docs
       docs = group_docs(docs)
+      merge_consecutive_marks(docs)
       make_doc_urls(docs)
       autolink(docs, ungrouped_docs)
       [docs, @stats]

--- a/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
@@ -152,7 +152,7 @@ header {
   background-color: $bg_color;
   position: fixed;
   width: 100%;
-  z-index: 1;
+  z-index: 2;
   img {
     padding-right: 6px;
     vertical-align: -4px;
@@ -177,7 +177,7 @@ header {
   padding-top: $breadcrumb_padding_top;
   position: fixed;
   width: 100%;
-  z-index: 1;
+  z-index: 2;
   margin-top: $header_height;
   #carat {
     height: 10px;
@@ -270,6 +270,17 @@ header {
       margin: -$content_top_offset 0 0;
     }
   }
+  .section-name {
+    p {
+       margin-bottom: inherit;
+       line-height: inherit;
+    }
+    code {
+      background-color: inherit;
+      padding: inherit;
+      color: inherit;
+    }
+  }
 }
 
 .section {
@@ -313,6 +324,29 @@ header {
       display: block;
       padding-top: $content_top_offset;
       margin: -$content_top_offset 0 0;
+    }
+  }
+}
+
+.section-name-container {
+  position: relative;
+  display: inline-block;
+
+  .section-name-link {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    margin-bottom: 0;
+  }
+
+  .section-name {
+    position: relative;
+    pointer-events: none;
+    z-index: 1;
+    a {
+      pointer-events: auto;
     }
   }
 }

--- a/lib/jazzy/themes/apple/templates/task.mustache
+++ b/lib/jazzy/themes/apple/templates/task.mustache
@@ -3,9 +3,10 @@
   <div class="task-name-container">
     <a name="/{{uid}}"></a>
     <a name="//apple_ref/{{language_stub}}/Section/{{name}}" class="dashAnchor"></a>
-    <a href="#/{{uid}}">
-      <h3 class="section-name">{{name}}</h3>
-    </a>
+    <div class="section-name-container">
+      <a class="section-name-link" href="#/{{uid}}"></a>
+      <h3 class="section-name">{{{name_html}}}</h3>
+    </div>
   </div>
   {{/name}}
   <ul>

--- a/lib/jazzy/themes/fullwidth/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/fullwidth/assets/css/jazzy.css.scss
@@ -201,13 +201,15 @@ code {
   font-family: $code_font;
 }
 
-p, li {
-  > code {
-    background: $code_bg_color;
-    padding: .2em;
-    &:before, &:after {
-      letter-spacing: -.2em;
-      content: "\00a0";
+.item-container, .top-matter {
+  p, li {
+    > code {
+      background: $code_bg_color;
+      padding: .2em;
+      &:before, &:after {
+        letter-spacing: -.2em;
+        content: "\00a0";
+      }
     }
   }
 }
@@ -367,6 +369,10 @@ pre code {
 .section-name {
   color: #666;
   display: block;
+
+  p {
+    margin-bottom: inherit;
+  }
 }
 
 .declaration .highlight {
@@ -390,6 +396,28 @@ pre code {
     &:before {
       content: "";
       display: block;
+    }
+  }
+}
+
+.section-name-container {
+  position: relative;
+
+  .section-name-link {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    margin-bottom: 0;
+  }
+
+  .section-name {
+    position: relative;
+    pointer-events: none;
+    z-index: 1;
+    a {
+      pointer-events: auto;
     }
   }
 }

--- a/lib/jazzy/themes/fullwidth/templates/doc.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/doc.mustache
@@ -35,7 +35,7 @@
       <article class="main-content">
 
         <section class="section">
-          <div class="section-content">
+          <div class="section-content top-matter">
             {{^hide_name}}<h1>{{name}}</h1>{{/hide_name}}
             {{> deprecation}}
             {{#declaration}}

--- a/lib/jazzy/themes/fullwidth/templates/task.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/task.mustache
@@ -3,9 +3,10 @@
   <div class="task-name-container">
     <a name="/{{uid}}"></a>
     <a name="//apple_ref/{{language_stub}}/Section/{{name}}" class="dashAnchor"></a>
-    <a href="#/{{uid}}">
-      <h3 class="section-name">{{name}}</h3>
-    </a>
+    <div class="section-name-container">
+      <a class="section-name-link" href="#/{{uid}}"></a>
+      <h3 class="section-name">{{{name_html}}}</h3>
+    </div>
   </div>
   {{/name}}
   <ul class="item-container">

--- a/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
@@ -182,7 +182,7 @@ header {
   background-color: $bg_color;
   position: fixed;
   width: 100%;
-  z-index: 2;
+  z-index: 3;
   img {
     padding-right: 6px;
     vertical-align: -4px;
@@ -204,7 +204,7 @@ header {
 #breadcrumbs-container {
   background-color: $bg_color;
   position: fixed;
-  z-index: 1;
+  z-index: 2;
   width: 100%;
 }
 
@@ -310,6 +310,16 @@ header {
       margin: -$content_top_offset 0 0;
     }
   }
+
+  .section-name {
+    p {
+       margin-bottom: inherit;
+       line-height: inherit;
+    }
+    code {
+      color: inherit;
+    }
+  }
 }
 
 .highlight {
@@ -352,6 +362,29 @@ header {
       display: block;
       padding-top: $content_top_offset;
       margin: -$content_top_offset 0 0;
+    }
+  }
+}
+
+.section-name-container {
+  position: relative;
+  display: inline-block;
+
+  .section-name-link {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    margin-bottom: 0;
+  }
+
+  .section-name {
+    position: relative;
+    pointer-events: none;
+    z-index: 1;
+    a {
+      pointer-events: auto;
     }
   }
 }

--- a/lib/jazzy/themes/jony/templates/task.mustache
+++ b/lib/jazzy/themes/jony/templates/task.mustache
@@ -3,9 +3,10 @@
   <div class="task-name-container">
     <a name="/{{uid}}"></a>
     <a name="//apple_ref/{{language_stub}}/Section/{{name}}" class="dashAnchor"></a>
-    <a href="#/{{uid}}">
-      <h3 class="section-name">{{name}}</h3>
-    </a>
+    <div class="section-name-container">
+      <a class="section-name-link" href="#/{{uid}}"></a>
+      <h3 class="section-name">{{{name_html}}}</h3>
+    </div>
   </div>
   {{/name}}
   <ul>


### PR DESCRIPTION
First chunk of displaying conditional extensions properly: generates section headers for type members added via conditional conformance.

For a type with various extensions depending on a generic parameter:

<img width="551" alt="Screenshot 2019-11-12 at 15 44 53" src="https://user-images.githubusercontent.com/26768470/68686394-7a4d2a00-0563-11ea-952f-e7acef09c59c.png">

Protocol with extensions providing conditional default implementations depending on associated type:
<img width="415" alt="Screenshot 2019-11-12 at 15 40 33" src="https://user-images.githubusercontent.com/26768470/68686017-df545000-0562-11ea-9a91-bceb56789d7a.png">

First three commits are groundwork to make the MARK task section headers behave, fourth commit actually adds the conditional extension stuff.  [Second commit](https://github.com/realm/jazzy-integration-specs/commit/bbbc8ad3d924b28d8746245fc57bb9baa2876439) in the specs changes shows the effect there, the earlier commit is huge because of the html/css changes that are user-invisible.

Remaining part of this is to actually show conditional protocol conformances.