### PR TITLE
Include protocol conformances in Swift docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   `name_html` mustache tag key for section headings.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Include protocol conformances added by extensions in Swift docs.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ##### Bug Fixes
 
 * None.

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -131,6 +131,7 @@ module Jazzy
     attr_accessor :unavailable
     attr_accessor :unavailable_message
     attr_accessor :generic_requirements
+    attr_accessor :inherited_types
 
     def usage_discouraged?
       unavailable || deprecated
@@ -151,6 +152,23 @@ module Jazzy
       else
         SourceMark.new
       end
+    end
+
+    def inherited_types?
+      inherited_types &&
+        !inherited_types.empty?
+    end
+
+    # Is there at least one inherited type that is not in the given list?
+    def other_inherited_types?(unwanted)
+      return false unless inherited_types?
+      inherited_types.any? { |t| !unwanted.include?(t) }
+    end
+
+    # SourceKit only sets modulename for imported modules
+    def type_from_doc_module?
+      !type.extension? ||
+        (swift? && usr && modulename.nil?)
     end
 
     def alternative_abstract

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -114,6 +114,10 @@ module Jazzy
         kind == 'source.lang.swift.decl.protocol'
       end
 
+      def swift_typealias?
+        kind == 'source.lang.swift.decl.typealias'
+      end
+
       def param?
         # SourceKit strangely categorizes initializer parameters as local
         # variables, so both kinds represent a parameter in jazzy.

--- a/lib/jazzy/stats.rb
+++ b/lib/jazzy/stats.rb
@@ -18,6 +18,10 @@ module Jazzy
       @undocumented_decls << decl
     end
 
+    def remove_undocumented(decl)
+      @undocumented_decls.delete(decl)
+    end
+
     def acl_included
       documented + undocumented
     end


### PR DESCRIPTION
This includes extensions that add protocol conformances to documentation -- currently these are usually ignored.

Add conformances to type declarations:
<img width="539" alt="Screenshot 2019-11-23 at 13 17 41" src="https://user-images.githubusercontent.com/26768470/69494300-d1cb8e00-0eb1-11ea-8a0e-b5f1b3f187da.png">
<img width="605" alt="Screenshot 2019-11-23 at 13 19 34" src="https://user-images.githubusercontent.com/26768470/69494302-d42de800-0eb1-11ea-9bb8-eeb7785e00ed.png">

Include all extension declarations of a type that add conformances, even if they don't add members to the type:
<img width="436" alt="Screenshot 2019-11-23 at 13 18 47" src="https://user-images.githubusercontent.com/26768470/69494320-ffb0d280-0eb1-11ea-8121-5e46a844a977.png">

Finally include all conditional extension declarations of the same type (instead of just the first):
<img width="426" alt="Screenshot 2019-11-24 at 18 13 49" src="https://user-images.githubusercontent.com/26768470/69499057-356fae80-0ee6-11ea-966a-21cc6fff7f09.png">

Rather a lot of code needed to avoid documenting the wrong extensions - turns out understanding Swift access levels across extensions and typealiases is tough...

[First specs commit](https://github.com/realm/jazzy-integration-specs/commit/de495d5356799dd85cc0875746f3b7138a4b8aa3) shows changes to projects, [second commit](https://github.com/realm/jazzy-integration-specs/commit/155aeceebf0a8b54558a76b8aa189c2b0dc63768) adds tests.
