### PR TITLE
Render bullet lists mixed with callouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Render bullet lists correctly when followed by a callout.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#785](https://github.com/realm/jazzy/issues/785)
 
 ## 0.12.0
 

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -82,21 +82,21 @@ module Jazzy
 
       def render_aside(type, text)
         <<-HTML
-<div class="aside aside-#{type.underscore.tr('_', '-')}">
+</ul><div class="aside aside-#{type.underscore.tr('_', '-')}">
     <p class="aside-title">#{type.underscore.humanize}</p>
     #{text}
-</div>
+</div><ul>
         HTML
       end
 
       def list(text, list_type)
         elided = text.gsub!(ELIDED_LI_TOKEN, '')
         return if text =~ /\A\s*\Z/ && elided
-        return text if text =~ /class="aside-title"/
         str = "\n"
         str << (list_type == :ordered ? "<ol>\n" : "<ul>\n")
         str << text
         str << (list_type == :ordered ? "</ol>\n" : "</ul>\n")
+        str.gsub(%r{\n?<ul>\n<\/ul>}, '')
       end
 
       def block_code(code, language)


### PR DESCRIPTION
Fix rendering for markdown lists that include both regular bullets and callout bullets.  Fairly easy to do this accidentally because blank lines [correctly] don't terminate the markdown list.
```markdown
- One
- Two

- note: Three
```
....before this the listiness of the pre-callout parts is lost.  The specs changes are one test for this, and then some user-invisible html whitespace changes throughout where there are stacked callouts.

Fixes #785 and part of 1132.