### PR TITLE
Format markup inside double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#785](https://github.com/realm/jazzy/issues/785)
 
+* Render markup of text inside double quotes.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#992](https://github.com/realm/jazzy/issues/992)
+
 ## 0.12.0
 
 ##### Breaking

--- a/lib/jazzy/jazzy_markdown.rb
+++ b/lib/jazzy/jazzy_markdown.rb
@@ -112,7 +112,6 @@ module Jazzy
       autolink: true,
       fenced_code_blocks: true,
       no_intra_emphasis: true,
-      quote: true,
       strikethrough: true,
       space_after_headers: false,
       tables: true,


### PR DESCRIPTION
Fixes #992 by turning off a redcarpet extension so that `"cut the *red* wire"` is rendered as html with italics as commonmark/xcode/github do.  Preserves the 'smart quotes' formatting.

Spec changes to do all the `<q>` -> `&ldquo;` changes and add a test.

Will cut a release after this one.