### PR TITLE
Fix `sourcekitten_sourcefile` in config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#992](https://github.com/realm/jazzy/issues/992)
 
+* Fix `sourcekitten_sourcefile` used from config file.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1137](https://github.com/realm/jazzy/issues/1137)
+
 ## 0.12.0
 
 ##### Breaking

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -176,7 +176,7 @@ module Jazzy
       command_line: ['-s', '--sourcekitten-sourcefile filepath1,…filepathN',
                      Array],
       description: 'File(s) generated from sourcekitten output to parse',
-      parse: ->(paths) { paths.map { |path| expand_path(path) } }
+      parse: ->(paths) { [paths].flatten.map { |path| expand_path(path) } }
 
     config_attr :source_directory,
       command_line: '--source-directory DIRPATH',


### PR DESCRIPTION
Fixes #1137 - when this attribute was changed to allow multiple values we forgot about the config file which needs to support it as a string as well for compatibility.

Tested this with single + multiple `-s` values on the CLI and in the config file.