### PR TITLE
[Config] Add new settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@
   [Bryce Pauken](https://github.com/brycepauken)
   [jpsim/SourceKitten#631](https://github.com/jpsim/SourceKitten/issues/631)
 
+* Add `custom_categories_unlisted_prefix` configuration setting. This
+  is the prefix for navigation section names that aren't explicitly
+  listed in `custom_categories`. Defaults to 'Other '.  
+  [JP Simard](https://github.com/jpsim)
+
+* Add `hide_unlisted_documentation` configuration setting. Setting this
+  to `true` hides documentation entries in the sidebar from the
+  `documentation` config value that aren't explicitly listed in
+  `custom_categories`.  
+  [JP Simard](https://github.com/jpsim)
+
 ##### Bug Fixes
 
 * Fix crash when SourceKit returns out of bounds string byte offsets.  

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -355,6 +355,18 @@ module Jazzy
                     'Example: https://git.io/v4Bcp'],
       default: []
 
+    config_attr :custom_categories_unlisted_prefix,
+      description: "Prefix for navigation section names that aren't "\
+                   'explicitly listed in `custom_categories`.',
+      default: 'Other '
+
+    config_attr :hide_unlisted_documentation,
+      command_line: '--[no-]hide-unlisted-documentation',
+      description: "Don't include documentation in the sidebar from the "\
+                   "`documentation` config value that aren't explicitly "\
+                   'listed in `custom_categories`.',
+      default: false
+
     config_attr :custom_head,
       command_line: '--head HTML',
       description: 'Custom HTML to inject into <head></head>.',

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -47,6 +47,14 @@ module Jazzy
           children: children,
         }
       end
+      .select do |structure|
+        if Config.instance.hide_unlisted_documentation
+          unlisted_prefix = Config.instance.custom_categories_unlisted_prefix
+          structure[:section] != "#{unlisted_prefix}Guides"
+        else
+          true
+        end
+      end
     end
 
     # Build documentation from the given options

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -29,31 +29,36 @@ module Jazzy
     # @return [Array] doc structure comprised of
     #                     section names & child names & URLs
     def self.doc_structure_for_docs(docs)
-      docs.map do |doc|
-        children = doc.children
-                      .sort_by { |c| [c.nav_order, c.name, c.usr || ''] }
-                      .flat_map do |child|
-          # FIXME: include arbitrarily nested extensible types
-          [{ name: child.name, url: child.url }] +
-            Array(child.children.select do |sub_child|
-              sub_child.type.swift_extensible? || sub_child.type.extension?
-            end).map do |sub_child|
-              { name: "– #{sub_child.name}", url: sub_child.url }
-            end
+      docs
+        .map do |doc|
+          children = children_for_doc(doc)
+          {
+            section: doc.name,
+            url: doc.url,
+            children: children,
+          }
         end
-        {
-          section: doc.name,
-          url: doc.url,
-          children: children,
-        }
-      end
-      .select do |structure|
-        if Config.instance.hide_unlisted_documentation
-          unlisted_prefix = Config.instance.custom_categories_unlisted_prefix
-          structure[:section] != "#{unlisted_prefix}Guides"
-        else
-          true
+        .select do |structure|
+          if Config.instance.hide_unlisted_documentation
+            unlisted_prefix = Config.instance.custom_categories_unlisted_prefix
+            structure[:section] != "#{unlisted_prefix}Guides"
+          else
+            true
+          end
         end
+    end
+
+    def self.children_for_doc(doc)
+      doc.children
+         .sort_by { |c| [c.nav_order, c.name, c.usr || ''] }
+         .flat_map do |child|
+        # FIXME: include arbitrarily nested extensible types
+        [{ name: child.name, url: child.url }] +
+          Array(child.children.select do |sub_child|
+            sub_child.type.swift_extensible? || sub_child.type.extension?
+          end).map do |sub_child|
+            { name: "– #{sub_child.name}", url: sub_child.url }
+          end
       end
     end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -62,8 +62,9 @@ module Jazzy
     # Group root-level docs by custom categories (if any) and type
     def self.group_docs(docs)
       custom_categories, docs = group_custom_categories(docs)
+      unlisted_prefix = Config.instance.custom_categories_unlisted_prefix
       type_categories, uncategorized = group_type_categories(
-        docs, custom_categories.any? ? 'Other ' : ''
+        docs, custom_categories.any? ? unlisted_prefix : ''
       )
       custom_categories + merge_categories(type_categories) + uncategorized
     end


### PR DESCRIPTION
Adds some new settings to improve documentation generation for SwiftLint.

* Add `custom_categories_unlisted_prefix` configuration setting. This is the prefix for navigation section names that aren't explicitly listed in `custom_categories`. Defaults to 'Other '.
* Add `hide_unlisted_documentation` configuration setting. Setting this to `true` hides documentation entries in the sidebar from the `documentation` config value that aren't explicitly listed in `custom_categories`.