### PR TITLE
Use best declaration with @escaping or @autoclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 * Fix crash when SourceKit returns out of bounds string byte offsets.  
   [JP Simard](https://github.com/jpsim)
 
+* Pick the right version of declarations with type attributes.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1148](https://github.com/realm/jazzy/issues/1148)
+
 ## 0.13.0
 
 ##### Breaking

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -441,7 +441,8 @@ module Jazzy
       annotated.empty? ||
         parsed &&
           (annotated.include?(' = default') || # SR-2608
-           parsed.match('@autoclosure|@escaping') || # SR-6321
+            (parsed.scan(/@autoclosure|@escaping/).count >
+             annotated.scan(/@autoclosure|@escaping/).count) || # SR-6321
            parsed.include?("\n"))
     end
 


### PR DESCRIPTION
Improve the SR-631 workaround (@escaping dropped from declaration) so it doesn't fire if the version of Swift in use has the fix.  Add a test.

Fixes #1148 (at least gets a correct declaration into docs, getting the preferred multi-line one is a separate problem...)