### PR TITLE
Xcode 11.4/Swift 5.2 fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
   swift:
     macos:
-      xcode: "11.2.0"
+      xcode: "11.4.0"
     environment: *bundler-environment
     steps:
       - checkout
@@ -29,7 +29,7 @@ jobs:
 
   objc:
     macos:
-      xcode: "11.2.0"
+      xcode: "11.4.0"
     environment: *bundler-environment
     steps:
       - checkout
@@ -41,7 +41,7 @@ jobs:
 
   cocoapods:
     macos:
-      xcode: "11.2.0"
+      xcode: "11.4.0"
     environment: *bundler-environment
     steps:
       - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ##### Enhancements
 
+* Support Xcode 11.4.  Default Objective-C property attributes are now
+  stripped from declarations: turn this off with
+  `--keep-default-property-attributes`.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#829](https://github.com/realm/jazzy/issues/829)
+
 * Render LaTeX expressions written using `$equation$` or `$$equation$$`
   syntax.  
   [Arthur Guiot](https://github.com/arguiot)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 11.2 installed to build the integration specs.
+You must have Xcode 11.4 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -156,6 +156,11 @@ module Jazzy
                    'projects.',
       default: ''
 
+    config_attr :keep_property_attributes,
+      command_line: '--[no-]keep-property-attributes',
+      description: 'Include the default Objective-C property attributes.',
+      default: false
+
     config_attr :config_file,
       command_line: '--config PATH',
       description: ['Configuration file (.yaml or .json)',

--- a/lib/jazzy/source_declaration/access_control_level.rb
+++ b/lib/jazzy/source_declaration/access_control_level.rb
@@ -36,7 +36,7 @@ module Jazzy
           end
         end
         acl = from_doc_explicit_declaration(doc)
-        acl || AccessControlLevel.public # fallback on public ACL
+        acl || AccessControlLevel.internal # fallback on internal ACL
       end
 
       def self.implicit_deinit?(doc)

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -448,10 +448,16 @@ module Jazzy
         parsed.include?("\n") # user formatting
     end
 
-    # Replace the fully qualified name of a type with its base name
-    def self.unqualify_name(annotated_decl, declaration)
-      annotated_decl.gsub(declaration.fully_qualified_name_regexp,
-                          declaration.name)
+    # Apply fixes to improve the compiler's declaration
+    def self.fix_up_compiler_decl(annotated_decl, declaration)
+      annotated_decl.
+        # Replace the fully qualified name of a type with its base name
+        gsub(declaration.fully_qualified_name_regexp,
+             declaration.name).
+        # Workaround for SR-9816
+        gsub(" {\n  get\n  }", '').
+        # Workaround for SR-12139
+        gsub(/mutating\s+mutating/, 'mutating')
     end
 
     # Find the best Swift declaration
@@ -478,10 +484,8 @@ module Jazzy
           inline_attrs, parsed_decl_body = split_decl_attributes(parsed_decl)
           parsed_decl_body.unindent(inline_attrs.length)
         else
-          # Strip ugly references to decl type name
-          unqualified = unqualify_name(annotated_decl_body, declaration)
-          # Workaround for SR-9816
-          unqualified.gsub(" {\n  get\n  }", '')
+          # Improve the compiler declaration
+          fix_up_compiler_decl(annotated_decl_body, declaration)
         end
 
       # @available attrs only in compiler 'interface' style


### PR DESCRIPTION
~Incomplete~ Workarounds and fixups for Xcode 11.4

Swift changes:
* SourceKit used to say “internal” when it didn’t know the ACL.  Now it leaves the field blank which is technically more honest but practically less helpful.  Workaround in jazzy to restore previous behaviour.
* ‘mutating’ keyword is duplicated. [SR-12139](https://bugs.swift.org/browse/SR-12139).
* Nested type names are minimally formed -- any prefix implied by context is removed.
* More properties have { get } suffixes -- getting close to being able to drop the ACL attrs
* Multiple properties defined on the same line of code with a shared attribute “public var a, b” are reported properly!
* Generic constraints more aggressively minimized -- if you write an essay that evaluates to “== Int” then that’s how it reads.
* ~`key.modulename` is broken for local dependencies.  This is what’s breaking Moya.  Will try and fix Swift, https://github.com/apple/swift/pull/29702, but may have to work around in sourcekitten.~ Fixed in beta 3.

ObjC changes:
* Many properties are now showing as `unsafe_unretained`. 
    * Changed jazzy to strip default attrs per #829.
* The order in which libclang prints out property attributes has changed. /sob
