### PR TITLE
Wrap long method names on category pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 ##### Enhancements
 
-* None.
+* Wrap long method names on category pages.  Use `name_html` in custom
+  mustache templates to take advantage of this.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#995](https://github.com/realm/jazzy/issues/995)
 
 ##### Bug Fixes
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -341,6 +341,7 @@ module Jazzy
       abstract = (item.abstract || '') + (item.discussion || '')
       {
         name:                       item.name,
+        name_html:                  item.name.gsub(':', ':<wbr>'),
         abstract:                   abstract,
         declaration:                item.display_declaration,
         language:                   item.display_language,

--- a/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
@@ -368,13 +368,15 @@ header {
     padding: 0;
   }
   .token, .direct-link {
+    display: inline-block;
+    text-indent: -20px;
     padding-left: 3px;
-    margin-left: 15px;
+    margin-left: 35px;
     font-size: 11.9px;
     transition: all 300ms;
   }
   .token-open {
-    margin-left: 0px;
+    margin-left: 20px;
   }
   .discouraged {
     text-decoration: line-through;

--- a/lib/jazzy/themes/apple/templates/task.mustache
+++ b/lib/jazzy/themes/apple/templates/task.mustache
@@ -22,10 +22,10 @@
         {{/direct_link}}
         {{^direct_link}}
         {{^usage_discouraged}}
-        <a class="token" href="#/{{usr}}">{{name}}</a>
+        <a class="token" href="#/{{usr}}">{{{name_html}}}</a>
         {{/usage_discouraged}}
         {{#usage_discouraged}}
-        <a class="token discouraged" href="#/{{usr}}">{{name}}</a>
+        <a class="token discouraged" href="#/{{usr}}">{{{name_html}}}</a>
         {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}

--- a/lib/jazzy/themes/fullwidth/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/fullwidth/assets/css/jazzy.css.scss
@@ -439,8 +439,10 @@ pre code {
   }
 
   .token, .direct-link {
+    display: inline-block;
+    text-indent: -20px;
     padding-left: 3px;
-    margin-left: 0px;
+    margin-left: 20px;
     font-size: 1rem;
   }
 

--- a/lib/jazzy/themes/fullwidth/templates/task.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/task.mustache
@@ -22,10 +22,10 @@
         {{/direct_link}}
         {{^direct_link}}
         {{^usage_discouraged}}
-        <a class="token" href="#/{{usr}}">{{name}}</a>
+        <a class="token" href="#/{{usr}}">{{{name_html}}}</a>
         {{/usage_discouraged}}
         {{#usage_discouraged}}
-        <a class="token discouraged" href="#/{{usr}}">{{name}}</a>
+        <a class="token discouraged" href="#/{{usr}}">{{{name_html}}}</a>
         {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}

--- a/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
@@ -406,15 +406,17 @@ header {
     padding: 0;
   }
   .token, .direct-link {
+    display: inline-block;
+    text-indent: -20px;
     padding-left: 3px;
-    margin-left: 35px;
+    margin-left: 55px;
     transition: all 300ms;
   }
   .discouraged {
     text-decoration: line-through;
   }
   .token-open {
-    margin-left: 25px;
+    margin-left: 45px;
   }
   .declaration-note {
     font-size: .85em;

--- a/lib/jazzy/themes/jony/templates/task.mustache
+++ b/lib/jazzy/themes/jony/templates/task.mustache
@@ -22,10 +22,10 @@
         {{/direct_link}}
         {{^direct_link}}
         {{^usage_discouraged}}
-        <a class="token" href="#/{{usr}}">{{name}}</a>
+        <a class="token" href="#/{{usr}}">{{{name_html}}}</a>
         {{/usage_discouraged}}
         {{#usage_discouraged}}
-        <a class="token discouraged" href="#/{{usr}}">{{name}}</a>
+        <a class="token discouraged" href="#/{{usr}}">{{{name_html}}}</a>
         {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}


### PR DESCRIPTION
Fixes #995 - add optional line-break tags and tweak css to indent nicely.

![Screenshot 2020-02-29 at 13 40 27](https://user-images.githubusercontent.com/26768470/75608906-af25c280-5afb-11ea-9eb8-1cb7d5b4f933.png)

![Screenshot 2020-02-29 at 13 47 35](https://user-images.githubusercontent.com/26768470/75608911-b51ba380-5afb-11ea-9e83-f407c3af0c97.png)

![Screenshot 2020-02-29 at 13 52 11](https://user-images.githubusercontent.com/26768470/75608914-b77dfd80-5afb-11ea-91d9-a25be516d689.png)

Spec changes everywhere because of all the `<wbr>`s.
