### PR TITLE
Allow #//apple_ref/… links to expand docs too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#995](https://github.com/realm/jazzy/issues/995)
 
+* Support Dash-style `apple_ref` links to specific API items, for more
+  stable and human-readable links from external docs.
+  [Paul Cantrell](https://github.com/pcantrell)
+  [#1167](https://github.com/realm/jazzy/pull/1167)
+
 ##### Bug Fixes
 
 * Don't generate documentation if the `xcodebuild` command fails.  

--- a/lib/jazzy/themes/apple/assets/js/jazzy.js
+++ b/lib/jazzy/themes/apple/assets/js/jazzy.js
@@ -23,7 +23,7 @@ function openCurrentItemIfClosed() {
   if (window.jazzy.docset) {
     return;
   }
-  var $link = $(`a[name="${location.hash.substring(1)}"]`).next('.token');
+  var $link = $(`a[name="${location.hash.substring(1)}"]`).nextAll('.token');
   $content = itemLinkToContent($link);
   if ($content.is(':hidden')) {
     toggleItem($link, $content);

--- a/lib/jazzy/themes/apple/assets/js/jazzy.js
+++ b/lib/jazzy/themes/apple/assets/js/jazzy.js
@@ -23,7 +23,7 @@ function openCurrentItemIfClosed() {
   if (window.jazzy.docset) {
     return;
   }
-  var $link = $(`.token[href="${location.hash}"]`);
+  var $link = $(`a[name="${location.hash.substring(1)}"]`).next('.token');
   $content = itemLinkToContent($link);
   if ($content.is(':hidden')) {
     toggleItem($link, $content);

--- a/lib/jazzy/themes/fullwidth/assets/js/jazzy.js
+++ b/lib/jazzy/themes/fullwidth/assets/js/jazzy.js
@@ -23,7 +23,7 @@ function openCurrentItemIfClosed() {
   if (window.jazzy.docset) {
     return;
   }
-  var $link = $(`a[name="${location.hash.substring(1)}"]`).next('.token');
+  var $link = $(`a[name="${location.hash.substring(1)}"]`).nextAll('.token');
   $content = itemLinkToContent($link);
   if ($content.is(':hidden')) {
     toggleItem($link, $content);

--- a/lib/jazzy/themes/fullwidth/assets/js/jazzy.js
+++ b/lib/jazzy/themes/fullwidth/assets/js/jazzy.js
@@ -23,7 +23,7 @@ function openCurrentItemIfClosed() {
   if (window.jazzy.docset) {
     return;
   }
-  var $link = $(`.token[href="${location.hash}"]`);
+  var $link = $(`a[name="${location.hash.substring(1)}"]`).next('.token');
   $content = itemLinkToContent($link);
   if ($content.is(':hidden')) {
     toggleItem($link, $content);

--- a/lib/jazzy/themes/jony/assets/js/jazzy.js
+++ b/lib/jazzy/themes/jony/assets/js/jazzy.js
@@ -23,7 +23,7 @@ function openCurrentItemIfClosed() {
   if (window.jazzy.docset) {
     return;
   }
-  var $link = $(`a[name="${location.hash.substring(1)}"]`).next('.token');
+  var $link = $(`a[name="${location.hash.substring(1)}"]`).nextAll('.token');
   $content = itemLinkToContent($link);
   if ($content.is(':hidden')) {
     toggleItem($link, $content);

--- a/lib/jazzy/themes/jony/assets/js/jazzy.js
+++ b/lib/jazzy/themes/jony/assets/js/jazzy.js
@@ -23,7 +23,7 @@ function openCurrentItemIfClosed() {
   if (window.jazzy.docset) {
     return;
   }
-  var $link = $(`.token[href="${location.hash}"]`);
+  var $link = $(`a[name="${location.hash.substring(1)}"]`).next('.token');
   $content = itemLinkToContent($link);
   if ($content.is(':hidden')) {
     toggleItem($link, $content);


### PR DESCRIPTION
Currently Jazzy generates `<a name=…>` tags for both USR-style anchors and Dash-style `apple_ref` anchors:

```html
<a name="/s:6Siesta8ResourceC4loadAA7Request_pyF"></a>
<a name="//apple_ref/swift/Method/load()" class="dashAnchor"></a>
<a class="token token-open" href="#/s:6Siesta8ResourceC4loadAA7Request_pyF">load()</a>
```

The `apple_ref` anchors have several advantages: they are human-readable, generally make for shorter links, and (most importantly) are less prone to changes between doc generation cycles and thus make for more stable long-term links from e.g. other documentation.

However, they have a shortcoming in Jazzy: a link of the form `Foo.html#//apple_ref/swift/Method/load()` currently scrolls to the correct item, but does not expand it.

This PR also expands the item when thus linked, just as `Foo.html#/s:6Siesta8ResourceC4loadAA7Request_pyF` would.