### PR TITLE
Add --pod-sources config option to fix #650

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ##### Enhancements
 
-* None.
+* Added a config option to provide sources of privately hosted pod
+  dependencies when using the `--podspec` option.
+  `--pod-sources url1,url2,…urlN`.  
+  [Jonathan Bailey](https://github.com/jon889)
+  [#650](https://github.com/realm/jazzy/issues/650)
 
 ##### Bug Fixes
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -291,10 +291,10 @@ module Jazzy
 
     config_attr :pod_sources,
       command_line: ['--pod-sources url1,url2,…urlN', Array],
-      description: 'A list of sources to find pod dependencies. Used only with '\
-                   '--podspec when the podspec contains references to privately '\
-                   'hosted pods. You must include the default pod source if '\
-                   'public pods are also used.',
+      description: 'A list of sources to find pod dependencies. Used only '\
+                   'with --podspec when the podspec contains references to '\
+                   'privately hosted pods. You must include the default pod '\
+                   'source if public pods are also used.',
       default: []
 
     config_attr :docset_icon,

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -289,6 +289,14 @@ module Jazzy
       parse: ->(ps) { PodspecDocumenter.create_podspec(Pathname(ps)) if ps },
       default: Dir['*.podspec{,.json}'].first
 
+    config_attr :pod_sources,
+      command_line: ['--pod-sources url1,url2,…urlN', Array],
+      description: 'A list of sources to find pod dependencies. Used only with '\
+                   '--podspec when the podspec contains references to privately '\
+                   'hosted pods. You must include the default pod source if '\
+                   'public pods are also used.',
+      default: []
+
     config_attr :docset_icon,
       command_line: '--docset-icon FILEPATH',
       parse: ->(di) { expand_path(di) }

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -18,8 +18,7 @@ module Jazzy
       Pod::Config.instance.with_changes(installation_root: installation_root,
                                         verbose: false) do
         sandbox = Pod::Sandbox.new(Pod::Config.instance.sandbox_root)
-        swift_version = compiler_swift_version(config.swift_version)
-        installer = Pod::Installer.new(sandbox, podfile(swift_version))
+        installer = Pod::Installer.new(sandbox, podfile(config))
         installer.install!
         stdout = Dir.chdir(sandbox.root) do
           targets = installer.pod_targets
@@ -135,10 +134,15 @@ module Jazzy
     end
 
     # rubocop:disable Metrics/MethodLength
-    def podfile(swift_version)
+    def podfile(config)
+      swift_version = compiler_swift_version(config.swift_version)
       podspec = @podspec
       path = pod_path
       @podfile ||= Pod::Podfile.new do
+        config.pod_sources.each do |src|
+          source src
+        end
+
         install! 'cocoapods',
                  integrate_targets: false,
                  deterministic_uuids: false


### PR DESCRIPTION
This adds the --pod-sources config option to fix #650 

It's used in the same way the sources option is used during `pod lib lint`

So `jazzy --podspec Identity.podspec --pod-sources 'https://cdn.cocoapods.org,https://example.com/private-pods.git'`