### PR TITLE
Fix module version not being used from podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix module version not being used from podspec.  
+  [Jonathan Bailey](https://github.com/jon889)
 
 ## 0.13.2
 

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -59,6 +59,7 @@ module Jazzy
       end
       unless config.version_configured
         config.version = podspec.version.to_s
+        config.version_configured = true
       end
       unless config.github_file_prefix_configured
         config.github_file_prefix = github_file_prefix(podspec)

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -45,6 +45,7 @@ module Jazzy
 
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/MethodLength
     def self.apply_config_defaults(podspec, config)
       return unless podspec
 
@@ -71,6 +72,7 @@ module Jazzy
     end
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -51,12 +51,15 @@ module Jazzy
 
       unless config.author_name_configured
         config.author_name = author_name(podspec)
+        config.author_name_configured = true
       end
       unless config.module_name_configured
         config.module_name = podspec.module_name
+        config.module_name_configured = true
       end
       unless config.author_url_configured
         config.author_url = podspec.homepage || github_file_prefix(podspec)
+        config.author_url_configured = true
       end
       unless config.version_configured
         config.version = podspec.version.to_s
@@ -64,10 +67,12 @@ module Jazzy
       end
       unless config.github_file_prefix_configured
         config.github_file_prefix = github_file_prefix(podspec)
+        config.github_file_prefix_configured = true
       end
       unless config.swift_version_configured
         trunk_swift_build = podspec.attributes_hash['pushed_with_swift_version']
         config.swift_version = trunk_swift_build if trunk_swift_build
+        config.swift_version_configured = true
       end
     end
     # rubocop:enable Metrics/CyclomaticComplexity


### PR DESCRIPTION
version_configured was being checked [here](https://github.com/realm/jazzy/blob/master/lib/jazzy/doc.rb#L46) to see if the version was set but if the --podspec option was used then this check would be false so the version wasn't used.

I'm not sure if the checks in doc.rb should be changed to check if the `config.version` is empty instead?

Also I'm not sure if the other `_configured` variables such as `author_name_configured` should be set to true as well for consistency or if that might break something?