### PR TITLE
Autolink Swift custom attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Fix module version not being used from podspec.  
   [Jonathan Bailey](https://github.com/jon889)
 
+* Autolink Swift custom attributes/property wrappers.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ## 0.13.2
 
 ##### Breaking

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -59,7 +59,7 @@ module Jazzy
 
       def full_command_line_name
         long_option_names = command_line.map do |opt|
-          Regexp.last_match(1) if opt =~ %r{
+          Regexp.last_match(1) if opt.to_s =~ %r{
             ^--           # starts with double dash
             (?:\[no-\])?  # optional prefix for booleans
             ([^\s]+)      # long option name

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -17,7 +17,7 @@ ELIDED_AUTOLINK_TOKEN = '36f8f5912051ae747ef441d6511ca4cb'.freeze
 def autolink_regex(middle_regex, after_highlight)
   start_tag_re, end_tag_re =
     if after_highlight
-      [/<span class="(?:n|kt|nc)">/, '</span>']
+      [/<span class="(?:n|kt|kd|nc)">/, '</span>']
     else
       ['<code>', '</code>']
     end
@@ -913,9 +913,9 @@ module Jazzy
     # The `after_highlight` flag is used to differentiate between the two modes.
     def self.autolink_text(text, doc, root_decls, after_highlight = false)
       text.autolink_block(doc.url, '[^\s]+', after_highlight) do |raw_name|
-        parts = raw_name
-                .split(/(?<!\.)\.(?!\.)/) # dot with no neighboring dots
-                .reject(&:empty?)
+        parts = raw_name.sub(/^@/, '') # ignore for custom attribute ref
+                        .split(/(?<!\.)\.(?!\.)/) # dot with no neighboring dots
+                        .reject(&:empty?)
 
         # First dot-separated component can match any ancestor or top-level doc
         first_part = parts.shift


### PR DESCRIPTION
In practice this is just property wrappers right now.

![Screenshot 2020-04-15 at 12 08 02](https://user-images.githubusercontent.com/26768470/79330629-c4bb4400-7f11-11ea-937a-60418d355e0a.png)

Fix some Ruby 2.7 (2.6?) warnings and add a test.