### PR TITLE
Dash docset online redirection and playground links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   [Jonathan Bailey](https://github.com/jon889)
   [#650](https://github.com/realm/jazzy/issues/650)
 
+* Improve Dash docset support: support online redirection when
+  `--root-url` is set, and provide `--docset-playground-url` to
+  support docset playground links.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ##### Bug Fixes
 
 * Fix module version not being used from podspec.  

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -329,6 +329,11 @@ module Jazzy
       description: 'GitHub URL file prefix of this project (e.g. '\
                    'https://github.com/realm/realm-cocoa/tree/v0.87.1)'
 
+    config_attr :docset_playground_url,
+      command_line: '--docset-playground-url URL',
+      description: 'URL of an interactive playground to demonstrate the '\
+                   'framework, linked to from the docset.'
+
     # ──────── Doc generation options ────────
     config_attr :disable_search,
       command_line: '--disable-search',

--- a/lib/jazzy/docset_builder.rb
+++ b/lib/jazzy/docset_builder.rb
@@ -43,6 +43,8 @@ module Jazzy
             template.read,
             lowercase_name: source_module.name.downcase,
             name: source_module.name,
+            root_url: config.root_url,
+            playground_url: config.docset_playground_url,
           )
         end
       end

--- a/lib/jazzy/docset_builder/info_plist.mustache
+++ b/lib/jazzy/docset_builder/info_plist.mustache
@@ -16,5 +16,13 @@
       <true/>
     <key>DashDocSetFamily</key>
       <string>dashtoc</string>
+    {{#root_url}}
+    <key>DashDocSetFallbackURL</key>
+      <string>{{{.}}}</string>
+    {{/root_url}}
+    {{#playground_url}}
+    <key>DashDocSetPlayURL</key>
+      <string>{{{.}}}</string>
+    {{/playground_url}}
   </dict>
 </plist>


### PR DESCRIPTION
Set the 'online version' key if we know it via `--root-url` and provide a new option `--docset-playground-url` to pass through playground link configuration.
