### PR TITLE
Force pages for specific types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   typeahead.js 1.3.1 (`fullwidth` theme only).  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Added a config option to specify type kinds that should be rendered 
+  as pages. The option is `--render-as-page` and it accepts a regular 
+  expression matching type kinds.  
+  [Nikolay Volosatov](https://github.com/bamx23)
+
 ##### Bug Fixes
 
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
   typeahead.js 1.3.1 (`fullwidth` theme only).  
   [John Fairhurst](https://github.com/johnfairh)
 
-* Added a config option to specify type kinds that should be rendered 
-  as pages. The option is `--render-as-page` and it accepts a regular 
-  expression matching type kinds.  
+* Added a config option `--[no-]extra-page-rendering` to enforce page
+  rendering for definitions meaned global (like classes, structs, enums etc.)
+  even if they don't have children.  
   [Nikolay Volosatov](https://github.com/bamx23)
 
 ##### Bug Fixes

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -436,6 +436,18 @@ module Jazzy
                    'is "Undocumented", put "" if no text is required',
       default: 'Undocumented'
 
+    config_attr :render_as_page_kinds,
+      command_line: '--render-as-page REGEX',
+      description: 'Regular expression that match type kinds for which page generation should be forced',
+      default: '',
+      parse: ->(r) { 
+        if r.to_s.empty?
+          nil
+        else
+          Regexp.new(r) 
+        end
+      }
+
     # rubocop:enable Style/AlignParameter
 
     def initialize

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -436,18 +436,15 @@ module Jazzy
                    'is "Undocumented", put "" if no text is required',
       default: 'Undocumented'
 
-    config_attr :render_as_page_kinds,
-      command_line: '--render-as-page REGEX',
-      description: 'Regular expression that match type kinds for which page '\
-                   'generation should be forced',
-      default: '',
-      parse: ->(r) {
-        if r.to_s.empty?
-          nil
-        else
-          Regexp.new(r)
-        end
-      }
+    config_attr :page_render_level,
+      command_line: '--page-render-level [no-children | global]',
+      description: 'When definition should be rendered as a page. '\
+                   'Value "no-children" means that only definitions with '\
+                   'no children should have their pages. Value "global" '\
+                   'means that pages will be generated for both '\
+                   'no-children-definitions and definitions meaned to be '\
+                   'global like classes, structs, enums etc.',
+      default: 'no-children'
 
     # rubocop:enable Style/AlignParameter
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -436,15 +436,12 @@ module Jazzy
                    'is "Undocumented", put "" if no text is required',
       default: 'Undocumented'
 
-    config_attr :page_render_level,
-      command_line: '--page-render-level [no-children | global]',
-      description: 'When definition should be rendered as a page. '\
-                   'Value "no-children" means that only definitions with '\
-                   'no children should have their pages. Value "global" '\
-                   'means that pages will be generated for both '\
-                   'no-children-definitions and definitions meaned to be '\
-                   'global like classes, structs, enums etc.',
-      default: 'no-children'
+    config_attr :extra_page_rendering,
+      command_line: '--[no-]extra-page-rendering',
+      description: 'Pages will be rendered for global definitions '\
+                   '(like classes, structs, enums etc.) even if they '\
+                   'don\'t have children.',
+      default: false
 
     # rubocop:enable Style/AlignParameter
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -438,13 +438,14 @@ module Jazzy
 
     config_attr :render_as_page_kinds,
       command_line: '--render-as-page REGEX',
-      description: 'Regular expression that match type kinds for which page generation should be forced',
+      description: 'Regular expression that match type kinds for which page '\
+                   'generation should be forced',
       default: '',
-      parse: ->(r) { 
+      parse: ->(r) {
         if r.to_s.empty?
           nil
         else
-          Regexp.new(r) 
+          Regexp.new(r)
         end
       }
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -406,6 +406,8 @@ module Jazzy
     end
 
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     # Build Mustache document from single parsed doc
     # @param [Config] options Build options
     # @param [Hash] doc_model Parsed doc. @see SourceKitten.parse
@@ -433,11 +435,16 @@ module Jazzy
       doc[:dash_type] = doc_model.type.dash_type
       doc[:declaration] = doc_model.display_declaration
       doc[:overview] = overview
+      doc[:parameters] = doc_model.parameters if
+        doc_model.parameters && doc_model.parameters.any?
+      doc[:return] = doc_model.return
       doc[:structure] = source_module.doc_structure
       doc[:tasks] = render_tasks(source_module, doc_model.children)
       doc[:module_name] = source_module.name
       doc[:author_name] = source_module.author_name
       doc[:github_url] = source_module.github_url
+      doc[:github_token_url] = gh_token_url(doc_model, source_module) unless
+        doc_model.children.any?
       doc[:dash_url] = source_module.dash_url
       doc[:path_to_root] = path_to_root
       doc[:deprecation_message] = doc_model.deprecation_message
@@ -446,5 +453,7 @@ module Jazzy
       doc.render.gsub(ELIDED_AUTOLINK_TOKEN, path_to_root)
     end
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
   end
 end

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -11,7 +11,8 @@ module Jazzy
 
     # Give the item its own page or just inline into parent?
     def render_as_page?
-      children.any?
+      children.any? ||
+        (Config.instance.render_as_page_kinds.match? type.kind if Config.instance.render_as_page_kinds)
     end
 
     def swift?

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -27,7 +27,8 @@ module Jazzy
     # When referencing this item from its parent category,
     # include the content or just link to it directly?
     def omit_content_from_parent?
-      false
+      Config.instance.extra_page_rendering &&
+        (children.any? || type.should_have_extra_page?)
     end
 
     # Element containing this declaration in the code

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -12,7 +12,8 @@ module Jazzy
     # Give the item its own page or just inline into parent?
     def render_as_page?
       children.any? ||
-        (Config.instance.render_as_page_kinds.match? type.kind if Config.instance.render_as_page_kinds)
+        (Config.instance.render_as_page_kinds.match? type.kind if
+          Config.instance.render_as_page_kinds)
     end
 
     def swift?

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -11,9 +11,25 @@ module Jazzy
 
     # Give the item its own page or just inline into parent?
     def render_as_page?
-      children.any? ||
-        (Config.instance.render_as_page_kinds.match? type.kind if
-          Config.instance.render_as_page_kinds)
+      case Config.instance.page_render_level
+      when 'no-children' then children.any?
+      when 'global' then children.any? || global_page?
+      end
+    end
+
+    # These sections are marked as global.
+    def global_page?
+      [
+        'Category',
+        'Class',
+        'Constant',
+        'Enumeration',
+        'Function',
+        'Global Variable',
+        'Protocol',
+        'Structure',
+        'Type Definition',
+      ].include? type.name
     end
 
     def swift?

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -147,7 +147,7 @@ module Jazzy
     def unsafe_filename
       result = url_name || name
       if render_as_page? && type.swift_global_function?
-        result += "_" + type_usr
+        result += '_' + type_usr
       end
       result
     end

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -11,8 +11,8 @@ module Jazzy
 
     # Give the item its own page or just inline into parent?
     def render_as_page?
-      children.any? || 
-        (Config.instance.extra_page_rendering && 
+      children.any? ||
+        (Config.instance.extra_page_rendering &&
           type.should_have_extra_page?)
     end
 

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -110,6 +110,7 @@ module Jazzy
     attr_accessor :line
     attr_accessor :column
     attr_accessor :usr
+    attr_accessor :type_usr
     attr_accessor :modulename
     attr_accessor :name
     attr_accessor :objc_name
@@ -141,6 +142,14 @@ module Jazzy
 
     def filepath
       CGI.unescape(url)
+    end
+
+    def unsafe_filename
+      result = url_name || name
+      if render_as_page? && type.swift_global_function?
+        result += "_" + type_usr
+      end
+      result
     end
 
     def constrained_extension?

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -11,25 +11,9 @@ module Jazzy
 
     # Give the item its own page or just inline into parent?
     def render_as_page?
-      case Config.instance.page_render_level
-      when 'no-children' then children.any?
-      when 'global' then children.any? || global_page?
-      end
-    end
-
-    # These sections are marked as global.
-    def global_page?
-      [
-        'Category',
-        'Class',
-        'Constant',
-        'Enumeration',
-        'Function',
-        'Global Variable',
-        'Protocol',
-        'Structure',
-        'Type Definition',
-      ].include? type.name
+      children.any? || 
+        (Config.instance.extra_page_rendering && 
+          type.should_have_extra_page?)
     end
 
     def swift?

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -144,8 +144,12 @@ module Jazzy
       def should_have_extra_page?
         # These kinds are meaned to be global and should be rendered
         # as page in extra-page-rendering mode.
+        swift_should_have_extra_page? || objc_should_have_extra_page?
+      end
+
+      def swift_should_have_extra_page?
+        # See `should_have_extra_page`
         [
-          # Swift
           'source.lang.swift.decl.class',
           'source.lang.swift.decl.enum',
           'source.lang.swift.decl.function.free',
@@ -157,8 +161,12 @@ module Jazzy
           'source.lang.swift.decl.extension.enum',
           'source.lang.swift.decl.extension.protocol',
           'source.lang.swift.decl.extension.struct',
+        ].include? kind
+      end
 
-          # Objective-C
+      def objc_should_have_extra_page?
+        # See `should_have_extra_page`
+        [
           'sourcekitten.source.lang.objc.decl.category',
           'sourcekitten.source.lang.objc.decl.class',
           'sourcekitten.source.lang.objc.decl.constant',

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -118,6 +118,10 @@ module Jazzy
         kind == 'source.lang.swift.decl.typealias'
       end
 
+      def swift_global_function?
+        kind == 'source.lang.swift.decl.function.free'
+      end
+
       def param?
         # SourceKit strangely categorizes initializer parameters as local
         # variables, so both kinds represent a parameter in jazzy.

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -137,6 +137,30 @@ module Jazzy
         kind == 'sourcekitten.source.lang.objc.decl.unexposed'
       end
 
+      def should_have_extra_page?
+        # These kinds are meaned to be global and should be rendered
+        # as page in extra-page-rendering mode.
+        [
+          # Swift
+          'source.lang.swift.decl.class',
+          'source.lang.swift.decl.enum',
+          'source.lang.swift.decl.function.free',
+          'source.lang.swift.decl.protocol',
+          'source.lang.swift.decl.struct',
+          'source.lang.swift.decl.var.global',
+
+          # Objective-C
+          'sourcekitten.source.lang.objc.decl.category',
+          'sourcekitten.source.lang.objc.decl.class',
+          'sourcekitten.source.lang.objc.decl.constant',
+          'sourcekitten.source.lang.objc.decl.enum',
+          'sourcekitten.source.lang.objc.decl.function',
+          'sourcekitten.source.lang.objc.decl.protocol',
+          'sourcekitten.source.lang.objc.decl.struct',
+          'sourcekitten.source.lang.objc.decl.typedef',
+        ].include? kind
+      end
+
       def self.overview
         Type.new('Overview')
       end

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -148,6 +148,11 @@ module Jazzy
           'source.lang.swift.decl.protocol',
           'source.lang.swift.decl.struct',
           'source.lang.swift.decl.var.global',
+          'source.lang.swift.decl.extension',
+          'source.lang.swift.decl.extension.class',
+          'source.lang.swift.decl.extension.enum',
+          'source.lang.swift.decl.extension.protocol',
+          'source.lang.swift.decl.extension.struct',
 
           # Objective-C
           'sourcekitten.source.lang.objc.decl.category',

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -138,7 +138,7 @@ module Jazzy
     end
 
     def self.sanitize_filename(doc)
-      unsafe_filename = doc.url_name || doc.name
+      unsafe_filename = doc.unsafe_filename
       sanitzation_enabled = Config.instance.use_safe_filenames
       if sanitzation_enabled && !doc.type.name_controlled_manually?
         return CGI.escape(unsafe_filename).gsub('_', '%5F').tr('%', '_')
@@ -565,6 +565,7 @@ module Jazzy
 
         declaration.file = Pathname(doc['key.filepath']) if doc['key.filepath']
         declaration.usr = doc['key.usr']
+        declaration.type_usr = doc['key.typeusr']
         declaration.modulename = doc['key.modulename']
         declaration.name = documented_name
         declaration.mark = current_mark

--- a/lib/jazzy/themes/apple/templates/doc.mustache
+++ b/lib/jazzy/themes/apple/templates/doc.mustache
@@ -43,6 +43,29 @@
               </div>
             {{/declaration}}
             {{{overview}}}
+            {{#parameters.count}}
+              <div>
+                <h4>Parameters</h4>
+                <table class="graybox">
+                  <tbody>
+                  {{#parameters}}
+                    {{> parameter}}
+                  {{/parameters}}
+                  </tbody>
+                </table>
+              </div>
+            {{/parameters.count}}
+            {{#return}}
+              <div>
+                <h4>Return Value</h4>
+                {{{return}}}
+              </div>
+            {{/return}}
+            {{#github_token_url}}
+              <div class="slightly-smaller">
+                <a href="{{{github_token_url}}}">Show on GitHub</a>
+              </div>
+            {{/github_token_url}}
           </section>
           {{> tasks}}
         </section>

--- a/lib/jazzy/themes/fullwidth/templates/doc.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/doc.mustache
@@ -52,6 +52,29 @@
               </div>
             {{/declaration}}
             {{{overview}}}
+            {{#parameters.count}}
+              <div>
+                <h4>Parameters</h4>
+                <table class="graybox">
+                  <tbody>
+                  {{#parameters}}
+                    {{> parameter}}
+                  {{/parameters}}
+                  </tbody>
+                </table>
+              </div>
+            {{/parameters.count}}
+            {{#return}}
+              <div>
+                <h4>Return Value</h4>
+                {{{return}}}
+              </div>
+            {{/return}}
+            {{#github_token_url}}
+              <div class="slightly-smaller">
+                <a href="{{{github_token_url}}}">Show on GitHub</a>
+              </div>
+            {{/github_token_url}}
           </div>
         </section>
 

--- a/lib/jazzy/themes/jony/templates/doc.mustache
+++ b/lib/jazzy/themes/jony/templates/doc.mustache
@@ -48,6 +48,29 @@
                 </div>
               {{/declaration}}
               {{{overview}}}
+              {{#parameters.count}}
+                <div>
+                  <h4>Parameters</h4>
+                  <table class="graybox">
+                    <tbody>
+                    {{#parameters}}
+                      {{> parameter}}
+                    {{/parameters}}
+                    </tbody>
+                  </table>
+                </div>
+              {{/parameters.count}}
+              {{#return}}
+                <div>
+                  <h4>Return Value</h4>
+                  {{{return}}}
+                </div>
+              {{/return}}
+              {{#github_token_url}}
+                <div class="slightly-smaller">
+                  <a href="{{{github_token_url}}}">Show on GitHub</a>
+                </div>
+              {{/github_token_url}}
             </section>
             {{> tasks}}
           </section>


### PR DESCRIPTION
It's my first contribution here so I hope that it is useful.
The purpose of this change is to allow page generation for specific types, like constants or type definitions. 

For example, I want to use this regex of type kinds:
```regex
^(sourcekitten\.)?source\.lang\.(objc|swift)\.decl\.(class|enum|function.*|protocol|struct|var\..*|category|constant|typedef)$
```

I haven't found any issue related to this problem. Hope I haven't forgotten to update anything. If there should be some tests point me where I should add them.