### PR TITLE
Ruby 2.7 and URL fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix warnings from Ruby 2.7.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1185](https://github.com/realm/jazzy/issues/1185)
 
 ## 0.13.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#1185](https://github.com/realm/jazzy/issues/1185)
 
+* Accept `root_url` without trailing slash.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1188](https://github.com/realm/jazzy/issues/1188)
+
 ## 0.13.3
 
 ##### Breaking

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -310,7 +310,8 @@ module Jazzy
     config_attr :root_url,
       command_line: ['-r', '--root-url URL'],
       description: 'Absolute URL root where these docs will be stored',
-      parse: ->(r) { URI(r) }
+      # ensure trailing slash for correct URI.join()
+      parse: ->(r) { URI(r.sub(%r{/?$}, '/')) }
 
     config_attr :dash_url,
       command_line: ['-d', '--dash_url URL'],

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -378,7 +378,7 @@ module Jazzy
       {
         name: mark.name,
         name_html: (render(doc_model, mark.name) if mark.name),
-        uid: URI.encode(uid),
+        uid: ERB::Util.url_encode(uid),
         items: items,
         pre_separator: mark.has_start_dash,
         post_separator: mark.has_end_dash,

--- a/lib/jazzy/source_module.rb
+++ b/lib/jazzy/source_module.rb
@@ -27,7 +27,8 @@ module Jazzy
       self.github_file_prefix = options.github_file_prefix
       self.author_url = options.author_url
       return unless options.dash_url
-      self.dash_url = "dash-feed://#{URI.encode(options.dash_url.to_s, /\W/)}"
+      self.dash_url =
+        "dash-feed://#{ERB::Util.url_encode(options.dash_url.to_s)}"
     end
 
     def all_declarations


### PR DESCRIPTION
Stop using `URI.encode`.  For docset feed URLs this does less %-encoding (doesn't encode '.') but that's fine, satisfies the example and generates good URLs that launch Dash properly.  Other use is (quite suspicious) generating anchor links for tasks.  These change a bit ('=' encoded now,) hopefully not too many external deep links to these.

Also fix the `root-url` trailing-slash issue #1188.