### PR TITLE
CSS improvements for apple and jony themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,11 @@
 
 ##### Bug Fixes
 
-* None.
+* Style fixes for `apple` and `jony` themes to codeblocks inside lists and
+  links.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#818](https://github.com/realm/jazzy/issues/818)
+  [#1177](https://github.com/realm/jazzy/issues/1177)
 
 ## 0.13.4
 

--- a/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
@@ -104,12 +104,18 @@ p code, li code {
   padding: 2px 4px;
   border-radius: 4px;
 }
+pre > code {
+  padding: 0;
+}
 
 // Links
 
 a {
   color: $link_color;
   text-decoration: none;
+  code {
+    color: inherit;
+  }
 }
 
 // Lists

--- a/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
@@ -101,11 +101,18 @@ pre, code {
   word-wrap: normal;
 }
 
+pre {
+  line-height: 1.6;
+}
+
 // Links
 
 a {
   color: $link_color;
   text-decoration: none;
+  code {
+    color: inherit;
+  }
 }
 
 // Lists


### PR DESCRIPTION
Tidy up some CSS nits - fixes #818, #1177.

![Screenshot 2020-06-22 at 19 50 09](https://user-images.githubusercontent.com/26768470/85324361-9afa3c80-b4c1-11ea-9f8c-bf6db1969a00.png)
