### PR TITLE
Improve Swift API docs for mixed language projects

### DIFF
--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -105,9 +105,11 @@ module Jazzy
     def display_other_language_declaration
       # Don't expose if API is NS_REFINED_FOR_SWIFT
       is_refined_for_swift = swift_name.to_s.include?('__')
-      
+
       return other_language_declaration unless
-        Config.instance.hide_objc? || Config.instance.hide_swift? || is_refined_for_swift
+        Config.instance.hide_objc? ||
+        Config.instance.hide_swift? ||
+        is_refined_for_swift
     end
 
     attr_accessor :file

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -136,6 +136,7 @@ module Jazzy
     attr_accessor :unavailable_message
     attr_accessor :generic_requirements
     attr_accessor :inherited_types
+    attr_accessor :swift_name
 
     def usage_discouraged?
       unavailable || deprecated

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -103,8 +103,11 @@ module Jazzy
     end
 
     def display_other_language_declaration
-      other_language_declaration unless
-        Config.instance.hide_objc? || Config.instance.hide_swift?
+      # Don't expose if API is NS_REFINED_FOR_SWIFT
+      is_refined_for_swift = swift_name.to_s.include?('__')
+      
+      return other_language_declaration unless
+        Config.instance.hide_objc? || Config.instance.hide_swift? || is_refined_for_swift
     end
 
     attr_accessor :file

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -540,6 +540,7 @@ module Jazzy
         declaration.type = SourceDeclaration::Type.new(doc['key.kind'])
         declaration.typename = doc['key.typename']
         declaration.objc_name = doc['key.name']
+        declaration.swift_name = doc['key.swift_name']
         documented_name = if Config.instance.hide_objc? && doc['key.swift_name']
                             doc['key.swift_name']
                           else


### PR DESCRIPTION
This PR hides API that is marked with `NS_REFINED_FOR_SWIFT` from `display_other_language_declaration`, and therefore in API documentation.

SourceKitten doesn't seem to expose if an API is refined for Swift, so I added a check for double underscores in the `display_other_language_declaration` getter.