### PR TITLE
Xcode 12 / Swift 5.3 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,12 @@ jobs:
 
   swift:
     macos:
-      xcode: "11.4.0"
+      xcode: "12.0.0"
     environment: *bundler-environment
     steps:
       - checkout
       - restore_cache: *restore-mac-bundler-cache
+      - run: echo 'chruby 2.6' >> ~/.bash_profile
       - run: bundle install
       - run: git submodule update --init --recursive
       - run: bundle exec rake swift_spec
@@ -29,11 +30,12 @@ jobs:
 
   objc:
     macos:
-      xcode: "11.4.0"
+      xcode: "12.0.0"
     environment: *bundler-environment
     steps:
       - checkout
       - restore_cache: *restore-mac-bundler-cache
+      - run: echo 'chruby 2.6' >> ~/.bash_profile
       - run: bundle install
       - run: git submodule update --init --recursive
       - run: bundle exec rake objc_spec
@@ -41,13 +43,14 @@ jobs:
 
   cocoapods:
     macos:
-      xcode: "11.4.0"
+      xcode: "12.0.0"
     environment: *bundler-environment
     steps:
       - checkout
       - restore_cache:
           key: cocoapods
       - restore_cache: *restore-mac-bundler-cache
+      - run: echo 'chruby 2.6' >> ~/.bash_profile
       - run: bundle install
       - run: git submodule update --init --recursive
       - run: bundle exec rake cocoapods_spec

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -214,12 +214,11 @@ describe_cli 'jazzy' do
     end
 
     describe 'Creates Siesta docs' do
+      # Siesta already has Docs/
+      # Use the default Swift version rather than the specified 4.0
       behaves_like cli_spec 'document_siesta',
-                            # Siesta already has Docs/
-                            '--output api-docs',
-                            # Use the default Swift version rather than the
-                            # specified 4.0
-                            '--swift-version='
+                            '--output api-docs ' \
+                            '--swift-version= '
     end
 
     describe 'Creates docs for Swift project with a variety of contents' do


### PR DESCRIPTION
Move CI to Xcode 12.0.0 image (still Catalina)

This uses Ruby 2.7 by default but this throws loads of warnings from cocoapods, fixed in their next release, so fixing at 2.6.
When Big Sur gets released I think I will modernise the Ruby requirements here, 2.0 is increasingly painful.

Stop building for arm7.
Spec updates for the NS_REFINED_FOR_SWIFT change & 'OSX' -> 'macOS' in `@available` decodes.

