### PR TITLE
Fix parameter doc comments for symgraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix parameter doc comments in Swft symbolgraph mode.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1244](https://github.com/realm/jazzy/issues/1244)
 
 ## 0.13.6
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![jazzy](images/logo.jpg)
 
-[![Build Status](https://circleci.com/gh/realm/jazzy.svg?style=svg)](https://circleci.com/gh/realm/jazzy)
+[![Build Status](https://github.com/realm/jazzy/actions/workflows/Tests.yml/badge.svg)](https://github.com/realm/jazzy/actions/workflows/Tests.yml)
 
 *jazzy is a command-line utility that generates documentation for Swift or Objective-C*
 

--- a/lib/jazzy/symbol_graph/sym_node.rb
+++ b/lib/jazzy/symbol_graph/sym_node.rb
@@ -130,6 +130,10 @@ module Jazzy
           hash['key.doc.comment'] = docs
           hash['key.doc.full_as_xml'] = ''
         end
+        if params = symbol.parameter_names
+          hash['key.doc.parameters'] =
+            params.map { |name| { 'name' => name } }
+        end
         if location = symbol.location
           hash['key.filepath'] = location[:filename]
           hash['key.doc.line'] = location[:line]

--- a/lib/jazzy/symbol_graph/symbol.rb
+++ b/lib/jazzy/symbol_graph/symbol.rb
@@ -13,6 +13,7 @@ module Jazzy
       attr_accessor :doc_comments # can be nil
       attr_accessor :availability # array, can be empty
       attr_accessor :generic_type_params # set, can be empty
+      attr_accessor :parameter_names # array, can be nil
 
       def name
         path_components[-1] || '??'
@@ -24,6 +25,9 @@ module Jazzy
         raw_decl = hash[:declarationFragments].map { |f| f[:spelling] }.join
         init_kind(hash[:kind][:identifier])
         init_declaration(raw_decl)
+        if func_signature = hash[:functionSignature]
+          init_func_signature(func_signature)
+        end
         init_acl(hash[:accessLevel])
         if location = hash[:location]
           init_location(location)
@@ -48,6 +52,13 @@ module Jazzy
         if kind == 'source.lang.swift.decl.class'
           declaration.sub!(/\s*:.*$/, '')
         end
+      end
+
+      # Remember pieces of methods for later markdown parsing
+
+      def init_func_signature(func_signature)
+        self.parameter_names =
+          (func_signature[:parameters] || []).map { |h| h[:name] }
       end
 
       # Mapping SymbolGraph's declkinds to SourceKit


### PR DESCRIPTION
Fixes #1244.

We need the list of known-good parameters because of the way the markdown gets parsed.

Spec update shows the parameter docs appearing in the test project.