### PR TITLE
Swift concurrency support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   [Brian Osborn](https://github.com/bosborn)
   [John Fairhurst](https://github.com/johnfairh)
 
+* Support Swift concurrency features: identify actors and asynchronous
+  methods.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ##### Bug Fixes
 
 * None.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 12.5 installed to build the integration specs.
+You must have Xcode 13 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -370,6 +370,8 @@ module Jazzy
         deprecation_message: item.deprecation_message,
         unavailable_message: item.unavailable_message,
         usage_discouraged: item.usage_discouraged?,
+        async: item.async,
+        declaration_note: item.declaration_note,
       }
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/jazzy/highlighter.rb
+++ b/lib/jazzy/highlighter.rb
@@ -2,7 +2,7 @@
 
 require 'rouge'
 
-# While Rouge is downlevel (Rouge PR#1715 unmerged)
+# While Rouge is downlevel (Rouge PR#1715 unreleased)
 module Rouge
   module Lexers
     class Swift

--- a/lib/jazzy/highlighter.rb
+++ b/lib/jazzy/highlighter.rb
@@ -7,7 +7,7 @@ module Rouge
   module Lexers
     class Swift
       prepend :root do
-        rule(/\b(?:async|await)\b/, Keyword)
+        rule(/\b(?:async|await|isolated)\b/, Keyword)
         rule(/\b(?:actor|nonisolated)\b/, Keyword::Declaration)
       end
     end

--- a/lib/jazzy/highlighter.rb
+++ b/lib/jazzy/highlighter.rb
@@ -2,6 +2,18 @@
 
 require 'rouge'
 
+# While Rouge is downlevel (Rouge PR#1715 unmerged)
+module Rouge
+  module Lexers
+    class Swift
+      prepend :root do
+        rule(/\b(?:async|await)\b/, Keyword)
+        rule(/\b(?:actor|nonisolated)\b/, Keyword::Declaration)
+      end
+    end
+  end
+end
+
 module Jazzy
   # This module helps highlight code
   module Highlighter

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -138,6 +138,7 @@ module Jazzy
     attr_accessor :unavailable_message
     attr_accessor :generic_requirements
     attr_accessor :inherited_types
+    attr_accessor :async
 
     def usage_discouraged?
       unavailable || deprecated
@@ -186,6 +187,14 @@ module Jazzy
     def type_from_doc_module?
       !type.extension? ||
         (swift? && usr && modulename.nil?)
+    end
+
+    # Info text for contents page by collapsed item name
+    def declaration_note
+      notes = [default_impl_abstract ? 'default implementation' : nil,
+               from_protocol_extension ? 'extension method' : nil,
+               async ? 'asynchronous' : nil].compact
+      notes.join(', ').humanize unless notes.empty?
     end
 
     def alternative_abstract

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -290,7 +290,7 @@ module Jazzy
         # Swift
         'source.lang.swift.decl.actor' => {
           jazzy: 'Actor',
-          dash: 'Class', # have asked Dash for something else
+          dash: 'Actor',
           global: true,
         }.freeze,
         'source.lang.swift.decl.function.accessor.address' => {

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -12,9 +12,22 @@ module Jazzy
 
       attr_reader :kind
 
-      def initialize(kind)
+      def initialize(kind, declaration = nil)
+        kind = fixup_kind(kind, declaration) if declaration
         @kind = kind
         @type = TYPES[kind]
+      end
+
+      # Improve kind from full declaration
+      def fixup_kind(kind, declaration)
+        if kind == 'source.lang.swift.decl.class' &&
+           declaration.include?(
+             '<syntaxtype.keyword>actor</syntaxtype.keyword>',
+           )
+          'source.lang.swift.decl.actor'
+        else
+          kind
+        end
       end
 
       def dash_type
@@ -115,7 +128,8 @@ module Jazzy
       end
 
       def swift_extensible?
-        kind =~ /^source\.lang\.swift\.decl\.(class|struct|protocol|enum)$/
+        kind =~
+          /^source\.lang\.swift\.decl\.(class|struct|protocol|enum|actor)$/
       end
 
       def swift_protocol?
@@ -274,6 +288,11 @@ module Jazzy
         }.freeze,
 
         # Swift
+        'source.lang.swift.decl.actor' => {
+          jazzy: 'Actor',
+          dash: 'Class', # have asked Dash for something else
+          global: true,
+        }.freeze,
         'source.lang.swift.decl.function.accessor.address' => {
           jazzy: 'Addressor',
           dash: 'Function',

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -621,7 +621,7 @@ module Jazzy
         declaration.inherited_types =
           inherited_types.map { |type| type['key.name'] }.compact
         declaration.async =
-          doc['key.async'] ||
+          doc['key.symgraph_async'] ||
           if xml_declaration = doc['key.fully_annotated_decl']
             swift_async?(xml_declaration)
           end
@@ -834,7 +834,9 @@ module Jazzy
       extensions.each do |ext|
         ext.children = ext.children.select do |ext_member|
           proto_member = protocol.children.find do |p|
-            p.name == ext_member.name && p.type == ext_member.type
+            p.name == ext_member.name &&
+              p.type == ext_member.type &&
+              p.async == ext_member.async
           end
 
           # Extension-only method, keep.

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -565,7 +565,9 @@ module Jazzy
         end
         declaration = SourceDeclaration.new
         declaration.parent_in_code = parent
-        declaration.type = SourceDeclaration::Type.new(doc['key.kind'])
+        declaration.type =
+          SourceDeclaration::Type.new(doc['key.kind'],
+                                      doc['key.fully_annotated_decl'])
         declaration.typename = doc['key.typename']
         declaration.objc_name = doc['key.name']
         documented_name = if Config.instance.hide_objc? && doc['key.swift_name']

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -524,6 +524,14 @@ module Jazzy
         .join("\n")
     end
 
+    # Exclude non-async routines that accept async closures
+    def self.swift_async?(fully_annotated_decl)
+      document = REXML::Document.new(fully_annotated_decl)
+      !document.elements['/*/syntaxtype.keyword[text()="async"]'].nil?
+    rescue
+      nil
+    end
+
     # Strip default property attributes because libclang
     # adds them all, even if absent in the original source code.
     DEFAULT_ATTRIBUTES = %w[atomic readwrite assign unsafe_unretained].freeze
@@ -612,6 +620,9 @@ module Jazzy
         inherited_types = doc['key.inheritedtypes'] || []
         declaration.inherited_types =
           inherited_types.map { |type| type['key.name'] }.compact
+        if xml_declaration = doc['key.fully_annotated_decl']
+          declaration.async = swift_async?(xml_declaration)
+        end
 
         next unless make_doc_info(doc, declaration)
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -528,7 +528,7 @@ module Jazzy
     def self.swift_async?(fully_annotated_decl)
       document = REXML::Document.new(fully_annotated_decl)
       !document.elements['/*/syntaxtype.keyword[text()="async"]'].nil?
-    rescue
+    rescue StandardError
       nil
     end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -620,9 +620,11 @@ module Jazzy
         inherited_types = doc['key.inheritedtypes'] || []
         declaration.inherited_types =
           inherited_types.map { |type| type['key.name'] }.compact
-        if xml_declaration = doc['key.fully_annotated_decl']
-          declaration.async = swift_async?(xml_declaration)
-        end
+        declaration.async =
+          doc['key.async'] ||
+          if xml_declaration = doc['key.fully_annotated_decl']
+            swift_async?(xml_declaration)
+          end
 
         next unless make_doc_info(doc, declaration)
 

--- a/lib/jazzy/symbol_graph/graph.rb
+++ b/lib/jazzy/symbol_graph/graph.rb
@@ -78,8 +78,13 @@ module Jazzy
 
       # Protocol conformance is redundant if it's unconditional
       # and already expressed in the type's declaration.
+      #
+      # Skip implementation-detail conformances.
       def redundant_conformance?(rel, type, protocol)
-        type && rel.constraints.empty? && type.conformance?(protocol)
+        return false unless type
+
+        (rel.constraints.empty? && type.conformance?(protocol)) ||
+          (type.actor? && rel.actor_protocol?)
       end
 
       # source is a member/protocol requirement of target

--- a/lib/jazzy/symbol_graph/relationship.rb
+++ b/lib/jazzy/symbol_graph/relationship.rb
@@ -22,6 +22,12 @@ module Jazzy
         kind == :defaultImplementationOf
       end
 
+      # Protocol conformances added by compiler to actor decls that
+      # users aren't interested in.
+      def actor_protocol?
+        %w[Actor Sendable].include?(target_fallback)
+      end
+
       def initialize(hash)
         kind = hash[:kind]
         unless KINDS.include?(kind)

--- a/lib/jazzy/symbol_graph/sym_node.rb
+++ b/lib/jazzy/symbol_graph/sym_node.rb
@@ -119,7 +119,7 @@ module Jazzy
 
       # approximately...
       def async?
-        symbol.declaration =~ /async[^\)]*$/
+        symbol.declaration =~ /\basync\b[^)]*$/
       end
 
       def full_declaration

--- a/lib/jazzy/symbol_graph/sym_node.rb
+++ b/lib/jazzy/symbol_graph/sym_node.rb
@@ -61,6 +61,10 @@ module Jazzy
         symbol.kind.end_with?('protocol')
       end
 
+      def actor?
+        symbol.kind.end_with?('actor')
+      end
+
       def constraints
         symbol.constraints
       end

--- a/lib/jazzy/symbol_graph/sym_node.rb
+++ b/lib/jazzy/symbol_graph/sym_node.rb
@@ -140,7 +140,7 @@ module Jazzy
           'key.accessibility' => symbol.acl,
           'key.parsed_decl' => declaration,
           'key.annotated_decl' => xml_declaration,
-          'key.async' => async?,
+          'key.symgraph_async' => async?,
         }
         if docs = symbol.doc_comments
           hash['key.doc.comment'] = docs

--- a/lib/jazzy/symbol_graph/sym_node.rb
+++ b/lib/jazzy/symbol_graph/sym_node.rb
@@ -25,6 +25,7 @@ module Jazzy
 
     # A SymNode is a node of the reconstructed syntax tree holding a symbol.
     # It can turn itself into SourceKit and helps decode extensions.
+    # rubocop:disable Metrics/ClassLength
     class SymNode < BaseNode
       attr_accessor :symbol
       attr_writer :override
@@ -116,6 +117,11 @@ module Jazzy
         " : #{superclass_name}"
       end
 
+      # approximately...
+      def async?
+        symbol.declaration =~ /async[^\)]*$/
+      end
+
       def full_declaration
         symbol.attributes
           .append(symbol.declaration + inherits_clause + where_clause)
@@ -134,6 +140,7 @@ module Jazzy
           'key.accessibility' => symbol.acl,
           'key.parsed_decl' => declaration,
           'key.annotated_decl' => xml_declaration,
+          'key.async' => async?,
         }
         if docs = symbol.doc_comments
           hash['key.doc.comment'] = docs
@@ -164,5 +171,6 @@ module Jazzy
         symbol <=> other.symbol
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/jazzy/symbol_graph/symbol.rb
+++ b/lib/jazzy/symbol_graph/symbol.rb
@@ -109,6 +109,7 @@ module Jazzy
           return 'swift.actor'
         end
         return kind unless keywords.member?('static')
+
         kind.gsub(/type/, 'static')
       end
 

--- a/lib/jazzy/symbol_graph/symbol.rb
+++ b/lib/jazzy/symbol_graph/symbol.rb
@@ -25,8 +25,8 @@ module Jazzy
       def initialize(hash)
         self.usr = hash[:identifier][:precise]
         self.path_components = hash[:pathComponents]
-        raw_decl = hash[:declarationFragments].map { |f| f[:spelling] }.join
-        init_kind(hash[:kind][:identifier])
+        raw_decl, keywords = parse_decl_fragments(hash[:declarationFragments])
+        init_kind(hash[:kind][:identifier], keywords)
         init_declaration(raw_decl)
         if func_signature = hash[:functionSignature]
           init_func_signature(func_signature)
@@ -42,6 +42,16 @@ module Jazzy
         end
         init_attributes(hash[:availability] || [])
         init_generic_type_params(hash)
+      end
+
+      def parse_decl_fragments(fragments)
+        decl = ''
+        keywords = Set.new
+        fragments.each do |frag|
+          decl += frag[:spelling]
+          keywords.add(frag[:spelling]) if frag[:kind] == 'keyword'
+        end
+        [decl, keywords]
       end
 
       # Repair problems with SymbolGraph's declprinter
@@ -89,17 +99,21 @@ module Jazzy
         'static.subscript' => 'function.subscript',
         'typealias' => 'typealias',
         'associatedtype' => 'associatedtype',
+        'actor' => 'actor',
       }.freeze
 
       # We treat 'static var' differently to 'class var'
-      def adjust_kind_for_declaration(kind)
-        return kind unless declaration =~ /\bstatic\b/
-
+      # We treat actors as first-class entities
+      def adjust_kind_for_declaration(kind, keywords)
+        if kind == 'swift.class' && keywords.member?('actor')
+          return 'swift.actor'
+        end
+        return kind unless keywords.member?('static')
         kind.gsub(/type/, 'static')
       end
 
-      def init_kind(kind)
-        adjusted = adjust_kind_for_declaration(kind)
+      def init_kind(kind, keywords)
+        adjusted = adjust_kind_for_declaration(kind, keywords)
         sourcekit_kind = KIND_MAP[adjusted.sub('swift.', '')]
         raise "Unknown symbol kind '#{kind}'" unless sourcekit_kind
 

--- a/lib/jazzy/themes/apple/templates/task.mustache
+++ b/lib/jazzy/themes/apple/templates/task.mustache
@@ -28,16 +28,11 @@
         <a class="token discouraged" href="#/{{usr}}">{{{name_html}}}</a>
         {{/usage_discouraged}}
         </code>
-        {{#default_impl_abstract}}
+        {{#declaration_note}}
           <span class="declaration-note">
-            Default implementation
+            {{.}}
           </span>
-        {{/default_impl_abstract}}
-        {{#from_protocol_extension}}
-          <span class="declaration-note">
-            Extension method
-          </span>
-        {{/from_protocol_extension}}
+        {{/declaration_note}}
       </div>
       <div class="height-container">
         <div class="pointer-container"></div>

--- a/lib/jazzy/themes/fullwidth/templates/task.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/task.mustache
@@ -28,16 +28,11 @@
         <a class="token discouraged" href="#/{{usr}}">{{{name_html}}}</a>
         {{/usage_discouraged}}
         </code>
-        {{#default_impl_abstract}}
+        {{#declaration_note}}
           <span class="declaration-note">
-            Default implementation
+            {{.}}
           </span>
-        {{/default_impl_abstract}}
-        {{#from_protocol_extension}}
-          <span class="declaration-note">
-            Extension method
-          </span>
-        {{/from_protocol_extension}}
+        {{/declaration_note}}
       </div>
       <div class="height-container">
         <div class="pointer-container"></div>

--- a/lib/jazzy/themes/jony/templates/task.mustache
+++ b/lib/jazzy/themes/jony/templates/task.mustache
@@ -28,16 +28,11 @@
         <a class="token discouraged" href="#/{{usr}}">{{{name_html}}}</a>
         {{/usage_discouraged}}
         </code>
-        {{#default_impl_abstract}}
+        {{#declaration_note}}
           <span class="declaration-note">
-            Default implementation
+            {{.}}
           </span>
-        {{/default_impl_abstract}}
-        {{#from_protocol_extension}}
-          <span class="declaration-note">
-            Extension method
-          </span>
-        {{/from_protocol_extension}}
+        {{/declaration_note}}
       </div>
       <div class="height-container">
         <div class="pointer-container"></div>


### PR DESCRIPTION
Sketch of Swift concurrency support.

1. Actors as first-class entities.  Bit scuffed because SourceKit still calls them 'classes'.
2. Pick out async methods/variables on contents pages.  Direction of travel on swift-evo is to permit overloading solely on `async` so will be helpful to show this given we just have the identifier name.
3. Syntax highlighting.  Rouge is going through one of its periods of being barely maintained, can work around this in jazzy until they merge my PR there.

![Screenshot 2021-06-20 at 12 02 14](https://user-images.githubusercontent.com/26768470/122671596-5f22b180-d1bf-11eb-8b89-c44569883786.png)

![Screenshot 2021-06-20 at 12 04 20](https://user-images.githubusercontent.com/26768470/122671660-b0cb3c00-d1bf-11eb-9117-ce9c6e743824.png)
