### PR TITLE
Adding a license header to Jazzy JS files

### DIFF
--- a/lib/jazzy/themes/apple/assets/js/jazzy.js
+++ b/lib/jazzy/themes/apple/assets/js/jazzy.js
@@ -1,3 +1,6 @@
+// Jazzy - https://github.com/realm/jazzy
+// Copyright Realm Inc.
+// SPDX-License-Identifier: MIT
 window.jazzy = {'docset': false}
 if (typeof window.dash != 'undefined') {
   document.documentElement.className += ' dash'

--- a/lib/jazzy/themes/apple/assets/js/jazzy.search.js
+++ b/lib/jazzy/themes/apple/assets/js/jazzy.search.js
@@ -1,3 +1,6 @@
+// Jazzy - https://github.com/realm/jazzy
+// Copyright Realm Inc.
+// SPDX-License-Identifier: MIT
 $(function(){
   var $typeahead = $('[data-typeahead]');
   var $form = $typeahead.parents('form');

--- a/lib/jazzy/themes/fullwidth/assets/js/jazzy.js
+++ b/lib/jazzy/themes/fullwidth/assets/js/jazzy.js
@@ -1,3 +1,6 @@
+// Jazzy - https://github.com/realm/jazzy
+// Copyright Realm Inc.
+// SPDX-License-Identifier: MIT
 window.jazzy = {'docset': false}
 if (typeof window.dash != 'undefined') {
   document.documentElement.className += ' dash'

--- a/lib/jazzy/themes/fullwidth/assets/js/jazzy.search.js
+++ b/lib/jazzy/themes/fullwidth/assets/js/jazzy.search.js
@@ -1,3 +1,6 @@
+// Jazzy - https://github.com/realm/jazzy
+// Copyright Realm Inc.
+// SPDX-License-Identifier: MIT
 $(function(){
   var $typeahead = $('[data-typeahead]');
   var $form = $typeahead.parents('form');

--- a/lib/jazzy/themes/jony/assets/js/jazzy.js
+++ b/lib/jazzy/themes/jony/assets/js/jazzy.js
@@ -1,3 +1,6 @@
+// Jazzy - https://github.com/realm/jazzy
+// Copyright Realm Inc.
+// SPDX-License-Identifier: MIT
 window.jazzy = {'docset': false}
 if (typeof window.dash != 'undefined') {
   document.documentElement.className += ' dash'


### PR DESCRIPTION
Hi Jazzy folk,

I noticed that while the other open source files Jazzy copies into the output identify their licensing, the ones from Jazzy themselves don't. I've taken the liberty of suggesting a source header to add to each of them.