### PR TITLE
Symbolgraph fixes for Xcode 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
   [John Fairhurst](https://github.com/johnfairh)
   [#1270](https://github.com/realm/jazzy/issues/1270)
 
+* Fix symbolgraph mode with Xcode 13.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ## 0.13.7
 
 The next release of Jazzy will require a minimum of Ruby 2.6.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Some examples:
    ```shell
    jazzy --module Combine --swift-build-tool symbolgraph
          --sdk iphoneos
-         --build-tool-arguments --target,arm64-apple-ios14.1
+         --build-tool-arguments -target,arm64-apple-ios14.1
    ```
    The `target` is the LLVM target triple and needs to match the SDK.  The
    default here is the target of the host system that Jazzy is running on,
@@ -261,7 +261,7 @@ Some examples:
    a `.swiftmodule`.  Again the `--source-directory` is searched by default
    if `-F` is not passed in.
 
-See `swift symbolgraph-extract --help` for all the things you can pass via
+See `swift symbolgraph-extract -help` for all the things you can pass via
 `--build-tool-arguments`: if your module has dependencies then you may need
 to add various search path options to let Swift load it.
 

--- a/lib/jazzy/symbol_graph.rb
+++ b/lib/jazzy/symbol_graph.rb
@@ -46,25 +46,25 @@ module Jazzy
 
       user_args = config.build_tool_arguments.join
 
-      if user_args =~ /--(?:module-name|minimum-access-level|output-dir)/
+      if user_args =~ /-(?:module-name|minimum-access-level|output-dir)/
         raise 'error: `--build-tool-arguments` for '\
-          "`--swift-build-tool symbolgraph` can't use `--module`, "\
-          '`--minimum-access-level`, or `--output-dir`.'
+          "`--swift-build-tool symbolgraph` can't use `-module`, "\
+          '`-minimum-access-level`, or `-output-dir`.'
       end
 
       # Default set
       args = [
-        "--module-name=#{config.module_name}",
-        '--minimum-access-level=private',
-        "--output-dir=#{output_path}",
-        '--skip-synthesized-members',
+        '-module-name', config.module_name,
+        '-minimum-access-level', 'private',
+        '-output-dir', output_path,
+        '-skip-synthesized-members'
       ]
 
       # Things user can override
-      args.append("--sdk=#{sdk(config)}") unless user_args =~ /--sdk/
-      args.append("--target=#{target}") unless user_args =~ /--target/
-      args.append("-F=#{config.source_directory}") unless user_args =~ /-F(?!s)/
-      args.append("-I=#{config.source_directory}") unless user_args =~ /-I/
+      args += ['-sdk', sdk(config)] unless user_args =~ /-sdk/
+      args += ['-target', target] unless user_args =~ /-target/
+      args += ['-F', config.source_directory.to_s] unless user_args =~ /-F(?!s)/
+      args += ['-I', config.source_directory.to_s] unless user_args =~ /-I/
 
       args + config.build_tool_arguments
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -234,7 +234,7 @@ describe_cli 'jazzy' do
       module_path = `swift build --build-path #{build_path} --show-bin-path`
       behaves_like cli_spec 'misc_jazzy_symgraph_features',
                             '--swift-build-tool symbolgraph ' \
-                              "--build-tool-arguments -I=#{module_path} "
+                              "--build-tool-arguments -I,#{module_path} "
     end
   end if !spec_subset || spec_subset == 'swift'
 


### PR DESCRIPTION
Fix some actual breakage with Xcode 13.

Prior to Swift 5.5, `swift symbolgraph-extract` supported longopts (--arg[=]value) as well as short opts, but this has now been deleted.  Unluckily I chose to use longopts in the jazzy driver so that needs updating.