### PR TITLE
Support for Swift SPI declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ##### Breaking
 
-* None.
+* Support Swift SPI groups.  Swift declarations marked `@_spi` are no longer
+  included in docs when `--min-acl` is set to `public` or `open`.  Use
+  `--include-spi-declarations` to include docs for these declarations.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1263](https://github.com/realm/jazzy/issues/1263)
 
 ##### Enhancements
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,9 @@ In Swift mode, Jazzy by default documents only `public` and `open` declarations.
 include declarations with a lower access level, set the `--min-acl` flag to `internal`,
 `fileprivate`, or `private`.
 
+By default, Jazzy does not document declarations marked `@_spi` when `--min-acl` is
+set to `public` or `open`.  Set the `--include-spi-declarations` flag to include them.
+
 In Objective-C mode, Jazzy documents all declarations found in the `--umbrella-header`
 header file and any other header files included by it.
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -476,6 +476,12 @@ module Jazzy
         'have children.',
       default: false
 
+    config_attr :include_spi_declarations,
+      command_line: '--[no-]include-spi-declarations',
+      description: 'Include Swift declarations marked `@_spi` even if '\
+        '--min-acl is set to `public` or `open`.',
+      default: false
+
     # rubocop:enable Layout/ArgumentAlignment
 
     def initialize

--- a/lib/jazzy/stats.rb
+++ b/lib/jazzy/stats.rb
@@ -5,7 +5,7 @@ module Jazzy
   class Stats
     include Config::Mixin
 
-    attr_reader :documented, :acl_skipped, :undocumented_decls
+    attr_reader :documented, :acl_skipped, :spi_skipped, :undocumented_decls
 
     def add_documented
       @documented += 1
@@ -13,6 +13,10 @@ module Jazzy
 
     def add_acl_skipped
       @acl_skipped += 1
+    end
+
+    def add_spi_skipped
+      @spi_skipped += 1
     end
 
     def add_undocumented(decl)
@@ -32,7 +36,7 @@ module Jazzy
     end
 
     def initialize
-      @documented = @acl_skipped = 0
+      @documented = @acl_skipped = @spi_skipped = 0
       @undocumented_decls = []
     end
 
@@ -53,6 +57,11 @@ module Jazzy
           "#{comma_list(config.min_acl.excluded_levels)} " \
           "#{symbol_or_symbols(acl_skipped)} " \
           '(use `--min-acl` to specify a different minimum ACL)'
+      end
+
+      if spi_skipped > 0
+        puts "skipped #{spi_skipped} SPI #{symbol_or_symbols(spi_skipped)} " \
+          '(use `--include-spi-declarations` to include these)'
       end
     end
 

--- a/lib/jazzy/symbol_graph/sym_node.rb
+++ b/lib/jazzy/symbol_graph/sym_node.rb
@@ -113,7 +113,7 @@ module Jazzy
       end
 
       def full_declaration
-        symbol.availability
+        symbol.attributes
           .append(symbol.declaration + inherits_clause + where_clause)
           .join("\n")
       end
@@ -147,6 +147,7 @@ module Jazzy
         unless children.empty?
           hash['key.substructure'] = children_to_sourcekit
         end
+        hash['key.symgraph_spi'] = true if symbol.spi
 
         hash
       end

--- a/lib/jazzy/symbol_graph/symbol.rb
+++ b/lib/jazzy/symbol_graph/symbol.rb
@@ -10,10 +10,11 @@ module Jazzy
       attr_accessor :declaration
       attr_accessor :kind
       attr_accessor :acl
+      attr_accessor :spi
       attr_accessor :location # can be nil, keys :filename :line :character
       attr_accessor :constraints # array, can be empty
       attr_accessor :doc_comments # can be nil
-      attr_accessor :availability # array, can be empty
+      attr_accessor :attributes # array, can be empty
       attr_accessor :generic_type_params # set, can be empty
       attr_accessor :parameter_names # array, can be nil
 
@@ -31,6 +32,7 @@ module Jazzy
           init_func_signature(func_signature)
         end
         init_acl(hash[:accessLevel])
+        self.spi = hash[:spi]
         if location = hash[:location]
           init_location(location)
         end
@@ -38,7 +40,7 @@ module Jazzy
         if comments_hash = hash[:docComment]
           init_doc_comments(comments_hash)
         end
-        init_availability(hash[:availability] || [])
+        init_attributes(hash[:availability] || [])
         init_generic_type_params(hash)
       end
 
@@ -159,8 +161,8 @@ module Jazzy
       # Availability
       # Re-encode this as Swift.  Should really teach Jazzy about these,
       # could maybe then do something smarter here.
-      def init_availability(avail_hash_list)
-        self.availability = avail_hash_list.map do |avail|
+      def availability_attributes(avail_hash_list)
+        avail_hash_list.map do |avail|
           str = '@available('
           if avail[:isUnconditionallyDeprecated]
             str += '*, deprecated'
@@ -188,6 +190,15 @@ module Jazzy
         str += ".#{hash[:minor]}" if hash[:minor]
         str += ".#{hash[:patch]}" if hash[:patch]
         str
+      end
+
+      def spi_attributes
+        spi ? ['@_spi(Unknown)'] : []
+      end
+
+      def init_attributes(avail_hash_list)
+        self.attributes =
+          availability_attributes(avail_hash_list) + spi_attributes
       end
 
       # Sort order


### PR DESCRIPTION
From #1263.

Take the `@_spi` attribute into consideration when generating docs.

By default exclude them if `min_acl` >= `public` to meet the default use case of 'generate docs for an end user'.  Provide a CLI flag to restore the old behaviour and support generating docs for internal users.