### PR TITLE
Run CI on Xcode 13 / Swift 5.5

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         spec: ["objc_spec", "swift_spec", "cocoapods_spec"]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.0.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         spec: ["objc_spec", "swift_spec", "cocoapods_spec"]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Correct line number references with Xcode 13.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ##### Bug Fixes
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -183,7 +183,7 @@ module Jazzy
       decls.map do |decl|
         {
           file: decl.file,
-          line: decl.line || decl.start_line,
+          line: decl.start_line || decl.line,
           symbol: decl.fully_qualified_name,
           symbol_kind: decl.type.kind,
           warning: 'undocumented',

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -188,9 +188,10 @@ describe_cli 'jazzy' do
     describe 'Creates docs with a module name, author name, project URL, ' \
       'xcodebuild options, and github info' do
       behaves_like cli_spec 'document_alamofire',
-                            '--skip-undocumented',
-                            # Ignore existing docs output
-                            '--clean'
+                            '--skip-undocumented ' \
+                              '--clean ' \
+                              '--xcodebuild-arguments ' \
+                              "-destination,'platform=OS X'"
     end
 
     describe 'Creates Realm Swift docs' do
@@ -210,7 +211,8 @@ describe_cli 'jazzy' do
                               '--root-url https://realm.io/docs/swift/' \
                               "#{realm_version}/api/ " \
                               '--xcodebuild-arguments ' \
-                              '-scheme,RealmSwift,SWIFT_VERSION=4.2 ' \
+                              '-scheme,RealmSwift,SWIFT_VERSION=4.2,' \
+                              "-destination,'platform=OS X' " \
                               "--head #{realm_head.shellescape}"
     end
 


### PR DESCRIPTION
Something odd going on with line numbers coming out of SourceKit but the result is better 🤷🏻 .

Realm ObjC changes because the importer is generating `async` Swift functions for me -- I have macOS 12 locally so expect (hope) CI on macOS 11 will fail.  GitHub Actions doesn't seem to know anything about macOS 12....

Something odd going on with `xcodebuild` meaning I need to explicitly set a destination to avoid a spammy warning.

Swift 5.5 has changed how `typealias`s are treated in interface generation to "look through" the typealias more often, meaning the declaration comes out differently to what the user has written.  Affects Realm Swift.  Will pursue upstream; affects DocC etc. too.