### PR TITLE
Work around Swift 5.6 modulename change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ##### Breaking
 
-* None.
+* When building with Swift 5.6 and not passing `—module` to Jazzy, declarations
+  may not be correctly identified as undocumented and docs may include unwanted
+  extensions.  Pass `—-module MyModuleName` to fix this.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ##### Enhancements
 

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -183,10 +183,12 @@ module Jazzy
       inherited_types.any? { |t| !unwanted.include?(t) }
     end
 
-    # SourceKit only sets modulename for imported modules
+    # Pre-Swift 5.6: SourceKit only sets modulename for imported modules
+    # Swift 5.6+: modulename is always set
     def type_from_doc_module?
       !type.extension? ||
-        (swift? && usr && modulename.nil?)
+        (swift? && usr &&
+          (modulename.nil? || modulename == Config.instance.module_name))
     end
 
     # Info text for contents page by collapsed item name

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -355,7 +355,9 @@ module Jazzy
     # Call things undocumented if they were compiled properly
     # and came from our module.
     def self.should_mark_undocumented(declaration)
-      declaration.usr && !declaration.modulename
+      declaration.usr &&
+        (declaration.modulename.nil? ||
+         declaration.modulename == Config.instance.module_name)
     end
 
     def self.process_undocumented_token(doc, declaration)


### PR DESCRIPTION
Workaround for apple/swift#39851 - mysteriously motivated breaking change to CursorInfo `key.modulename`, unfortunately jazzy relied on the behavior that is broken.
