### PR TITLE
Correct symgraph module names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@
 
 ##### Bug Fixes
 
-* None.
+* In Swift symbolgraph mode, stop including extensions to types that are beneath
+  the minimum ACL.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1291](https://github.com/realm/jazzy/issues/1291)
 
 ## 0.14.1
 

--- a/lib/jazzy/symbol_graph.rb
+++ b/lib/jazzy/symbol_graph.rb
@@ -28,7 +28,7 @@ module Jazzy
         Dir[tmp_dir + '/*.symbols.json'].map do |filename|
           # The @ part is for extensions in our module (before the @)
           # of types in another module (after the @).
-          filename =~ /(.*?)(@(.*?))?\.symbols/
+          File.basename(filename) =~ /(.*?)(@(.*?))?\.symbols/
           module_name = Regexp.last_match[3] || Regexp.last_match[1]
           {
             filename =>


### PR DESCRIPTION
Fixes #1291.

Spec updates show the bug being fixed there along with some `isolated` formatting improvements from the latest Xcode 13.2.