### PR TITLE
Swift 5.6

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         spec: ["objc_spec", "swift_spec", "cocoapods_spec"]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         spec: ["objc_spec", "swift_spec", "cocoapods_spec"]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.3.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ##### Breaking
 
-* When building with Swift 5.6 and not passing `—module` to Jazzy, declarations
+* When building with Swift 5.6 and not passing `—-module` to Jazzy, declarations
   may not be correctly identified as undocumented and docs may include unwanted
   extensions.  Pass `—-module MyModuleName` to fix this.  
   [John Fairhurst](https://github.com/johnfairh)
@@ -15,6 +15,9 @@
 * Issue a warning on some combinations of Objective-C flags.  
   [John Fairhurst](https://github.com/johnfairh)
   [#900](https://github.com/realm/jazzy/issues/900)
+
+* Support Swift 5.6.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ##### Bug Fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 13.2 installed to build the integration specs.
+You must have Xcode 13.3 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 13.3 installed to build the integration specs.
+You must have Xcode 13.2 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/Rakefile
+++ b/Rakefile
@@ -105,10 +105,12 @@ begin
   desc 'Vendors SourceKitten'
   task :sourcekitten do
     sk_dir = 'SourceKitten'
-    Dir.chdir(sk_dir) do
-      `swift build -c release`
+    bin_path = Dir.chdir(sk_dir) do
+      build_cmd = 'swift build -c release --arch arm64 --arch x86_64'
+      `#{build_cmd}`
+      `#{build_cmd} --show-bin-path`.chomp
     end
-    FileUtils.cp_r "#{sk_dir}/.build/release/sourcekitten", 'bin'
+    FileUtils.cp_r "#{bin_path}/sourcekitten", 'bin'
   end
 
   #-- Theme Dependencies -----------------------------------------------------#


### PR DESCRIPTION
updated sourcekitten for sourcekit change

jazzy_swift - improved `nonisolated` decl printing

realm_objc - new `@unchecked Sendable` conformances for ObjC types

jazzy_objc - Sendable, plus an interesting consequence of the module-name changes that I’ll leave unchanged (module name in .jazzy.yaml doesn’t match SPM’s opinion) for coverage.

realm_swift - probably a Swift bug to do with `override` vs. `@objc`, opened [SR-15815](https://bugs.swift.org/browse/SR-15815)