### PR TITLE
Update CI to macOS 12

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -25,13 +25,13 @@ jobs:
           bundle exec danger --verbose
 
   spec:
-    runs-on: macos-11
+    runs-on: macos-12
     continue-on-error: true
     strategy:
       matrix:
         spec: ["objc_spec", "swift_spec", "cocoapods_spec"]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.3.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 13.2 installed to build the integration specs.
+You must have Xcode 13.3 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -108,8 +108,10 @@ describe_cli 'jazzy' do
     s.replace_path ROOT.to_s, 'ROOT'
     s.replace_pattern /^[\d\s:.-]+ ruby\[\d+:\d+\] warning:.*$\n?/, ''
     # Remove version numbers from CocoaPods dependencies
-    # to make specs resilient against dependecy updates.
+    # to make specs resilient against dependency updates.
     s.replace_pattern(/(Installing \w+ )\((.*)\)/, '\1(X.Y.Z)')
+    # Xcode 13.3 workaround
+    s.replace_pattern(/202.*?IDEWatchSupportCore\n/, '')
   end
 
   require 'shellwords'


### PR DESCRIPTION
Try CI on macOS 12 / Xcode 13.3 / Swift 5.6 again.

(Xcode 13.4 not quite there on GitHub, no specs changes locally)

realm_objc - new @unchecked Sendable conformances for ObjC types

realm_swift - probably a Swift bug to do with override vs. @objc, now apple/swift#58092

jazzy_swift - improved nonisolated decl printing

jazzy_objc - Sendable, plus an interesting consequence of the module-name changes that I’ll leave unchanged (module name in .jazzy.yaml doesn’t match SPM’s opinion) for coverage

symgraph - output has started including synthesised initialisers