### PR TITLE
Update CI to Xcode 14.1

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         spec: ["objc_spec", "swift_spec", "cocoapods_spec"]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Symbolgraph changes only: the `AnyActor` conformance that disappeared during 14.0 is baaack.