### PR TITLE
Better handling of bad sourcekitten json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Issue a warning instead of crashing on declarations without names.  
+  [#1325](https://github.com/realm/jazzy/issues/1325)
+  [John Fairhurst](https://github.com/johnfairh)
 
 ## 0.14.3
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -603,6 +603,14 @@ module Jazzy
             "for `#{declaration.type.kind}`."
         end
 
+        unless documented_name
+          warn 'Found a declaration without `key.name` that will be ' \
+            'ignored.  Documentation may be incomplete.  This is probably ' \
+            'caused by unresolved compiler errors: check the sourcekitten ' \
+            'output for error messages.'
+          next
+        end
+
         declaration.file = Pathname(doc['key.filepath']) if doc['key.filepath']
         declaration.usr = doc['key.usr']
         declaration.type_usr = doc['key.typeusr']


### PR DESCRIPTION
Fixes #1325 

Issue a warning instead of crashing when json is missing key.name -- only known reason for this involves Objc categories and compiler errors.