### PR TITLE
Docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,16 +214,14 @@ sourcekitten doc --objc $(pwd)/MyProject/MyProject.h \
       -I $(pwd) -fmodules > objcDoc.json
 
 # Feed both outputs to Jazzy as a comma-separated list
-jazzy --sourcekitten-sourcefile swiftDoc.json,objcDoc.json
+jazzy --module MyProject --sourcekitten-sourcefile swiftDoc.json,objcDoc.json
 ```
 
 ### Docs from `.swiftmodule`s or frameworks
 
-*This feature is new and relies on a new Swift feature: there may be crashes
-and mistakes: reports welcome.*
+*This feature is new: there may be crashes and mistakes: reports welcome.*
 
-Swift 5.3 adds support for symbol graph generation from `.swiftmodule` files.
-This looks to be part of Apple's toolchain for generating their online docs.
+Swift 5.3 added support for symbol graph generation from `.swiftmodule` files.
 
 Jazzy can use this to generate API documentation.  This is faster than using
 the source code directly but does have limitations: for example documentation
@@ -390,6 +388,10 @@ extension MyType {
   …
 }
 ```
+
+When Jazzy is using `--swift-build-tool symgraph` the source file names and
+line numbers may not be available: in this case the ordering is approximately
+alphabetical by symbol name and USR: the order is stable for the same input.
 
 Jazzy does not normally create separate web pages for declarations that do not
 have any members: instead they are entirely nested into their parent page.  Use

--- a/README.md
+++ b/README.md
@@ -363,8 +363,8 @@ documentation.
 ### Documentation structure
 
 Jazzy arranges documentation into categories.  The default categories are things
- like “Classes” and “Structures” corresponding to programming-language concepts,
- as well as “Guides” if relevant.
+like _Classes_ and _Structures_ corresponding to programming-language concepts,
+as well as _Guides_ if `--documentation` is set.
 
 You can customize the categories and their contents using `custom_categories` in
 the config file — see the ReSwift [docs](https://reswift.github.io/ReSwift/) and
@@ -373,7 +373,7 @@ for an example.
 
 Within each category the items are ordered first alphabetically by source
 filename, and then by declaration order within the file.  You can use
-`// MARK: ` comments within the file to create subheadings on the page, for
+`// MARK:` comments within the file to create subheadings on the page, for
 example to split up properties and methods.  There’s no way to customize this
 order short of editing the generated web pages.
 
@@ -389,7 +389,7 @@ extension MyType {
   // MARK: Subheading for this group of methods
   …
 }
-```swift
+```
 
 Jazzy does not normally create separate web pages for declarations that do not
 have any members: instead they are entirely nested into their parent page.  Use
@@ -463,16 +463,15 @@ See [this document](ObjectiveC.md).
 
 **Missing docset**
 
-Jazzy only produces a docset if you set the `--module` flag.
+Jazzy only builds a docset when you set the `--module` flag.
 
 **Unable to pass --build-tool-arguments containing commas**
 
-If you want Jazzy to run something like `xcodebuild -scheme Scheme -destination 'a=x,b=y,c=z'
-then you must use the config file instead of the `--build-tool-arguments` flag because the
-CLI parser that jazzy uses cannot handle arguments that themselves contain commas.
+If you want Jazzy to run something like `xcodebuild -scheme Scheme -destination 'a=x,b=y,c=z'`
+then you must use the config file instead of the CLI flag because the CLI parser
+that Jazzy uses cannot handle arguments that themselves contain commas.
 
 The example config file here would be:
-
 ```yaml
 build_tool_arguments:
   - "-scheme"

--- a/README.md
+++ b/README.md
@@ -362,10 +362,39 @@ documentation.
 
 ### Documentation structure
 
-By default Jazzy does not create separate web pages for declarations that do
-not have any members: instead they are nested into some parent page.  Use the
-`--separate-global-declarations` flag to change this and always create pages
-for declarations that can be directly accessed from client code.
+Jazzy arranges documentation into categories.  The default categories are things
+ like “Classes” and “Structures” corresponding to programming-language concepts,
+ as well as “Guides” if relevant.
+
+You can customize the categories and their contents using `custom_categories` in
+the config file — see the ReSwift [docs](https://reswift.github.io/ReSwift/) and
+[config file](https://github.com/ReSwift/ReSwift/blob/e94737282850fa038b625b4e351d1608a3d02cee/.jazzy.json)
+for an example.
+
+Within each category the items are ordered first alphabetically by source
+filename, and then by declaration order within the file.  You can use
+`// MARK: ` comments within the file to create subheadings on the page, for
+example to split up properties and methods.  There’s no way to customize this
+order short of editing the generated web pages.
+
+Swift extensions and Objective-C categories allow type members to be declared
+across multiple source files.  In general, extensions follow the main type
+declaration: first extensions from the same source file, then extensions from
+other files ordered alphabetically by filename.  Swift conditional extensions
+(`extension A where …`) always appear beneath unconditional extensions.
+
+Use this pattern to add or customize the subheading before extension members:
+```swift
+extension MyType {
+  // MARK: Subheading for this group of methods
+  …
+}
+```swift
+
+Jazzy does not normally create separate web pages for declarations that do not
+have any members: instead they are entirely nested into their parent page.  Use
+the `--separate-global-declarations` flag to change this and  create pages for
+these empty types.
 
 ### Choosing the Swift language version
 
@@ -429,6 +458,37 @@ Check the `--min-acl` setting -- see [above](#controlling-what-is-documented).
 ### Objective-C
 
 See [this document](ObjectiveC.md).
+
+### Miscellaneous
+
+**Missing docset**
+
+Jazzy only produces a docset if you set the `--module` flag.
+
+**Unable to pass --build-tool-arguments containing commas**
+
+If you want Jazzy to run something like `xcodebuild -scheme Scheme -destination 'a=x,b=y,c=z'
+then you must use the config file instead of the `--build-tool-arguments` flag because the
+CLI parser that jazzy uses cannot handle arguments that themselves contain commas.
+
+The example config file here would be:
+
+```yaml
+build_tool_arguments:
+  - "-scheme"
+  - "Scheme"
+  - "-destination"
+  - "a=x,b=y,c=z"
+```
+
+**Errors in Xcode Run Script phase**
+
+Running Jazzy from an Xcode build phase can go wrong in hard-to-understand ways
+when Jazzy has to run `xcodebuild`.
+
+Users [have reported](https://github.com/realm/jazzy/issues/1012) that error
+messages about symbols lacking USRs can be fixed by unsetting
+`LLVM_TARGET_TRIPLE_SUFFIX` as part of the run script.
 
 ### Installation Problems
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ jazzy --module MyProject --sourcekitten-sourcefile swiftDoc.json,objcDoc.json
 
 ### Docs from `.swiftmodule`s or frameworks
 
-*This feature is new: there may be crashes and mistakes: reports welcome.*
+*This feature is new: there may be crashes and mistakes. Reports welcome.*
 
 Swift 5.3 added support for symbol graph generation from `.swiftmodule` files.
 
@@ -390,11 +390,11 @@ extension MyType {
 ```
 
 When Jazzy is using `--swift-build-tool symgraph` the source file names and
-line numbers may not be available: in this case the ordering is approximately
-alphabetical by symbol name and USR: the order is stable for the same input.
+line numbers may not be available. In this case the ordering is approximately
+alphabetical by symbol name and USR; the order is stable for the same input.
 
 Jazzy does not normally create separate web pages for declarations that do not
-have any members: instead they are entirely nested into their parent page.  Use
+have any members -- instead they are entirely nested into their parent page.  Use
 the `--separate-global-declarations` flag to change this and  create pages for
 these empty types.
 

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Within each category the items are ordered first alphabetically by source
 filename, and then by declaration order within the file.  You can use
 `// MARK:` comments within the file to create subheadings on the page, for
 example to split up properties and methods.  There’s no way to customize this
-order short of editing the generated web pages.
+order short of editing either the generated web page or the SourceKitten JSON.
 
 Swift extensions and Objective-C categories allow type members to be declared
 across multiple source files.  In general, extensions follow the main type
@@ -480,10 +480,10 @@ build_tool_arguments:
   - "a=x,b=y,c=z"
 ```
 
-**Errors in Xcode Run Script phase**
+**Errors running in an Xcode Run Script phase**
 
-Running Jazzy from an Xcode build phase can go wrong in hard-to-understand ways
-when Jazzy has to run `xcodebuild`.
+Running Jazzy from an Xcode build phase can go wrong in cryptic ways when Jazzy
+has to run `xcodebuild`.
 
 Users [have reported](https://github.com/realm/jazzy/issues/1012) that error
 messages about symbols lacking USRs can be fixed by unsetting


### PR DESCRIPTION
Fixes #1012, fixes #921, fixes #651 - added to common problems/solutions
(Decided not to add a warning for missing `—module`, would affect too many projects that are working just fine.)

Fixes #77 - added brief `custom_categories` explanation, nothing else useful to do with this.

Fixes #1043, fixes #428 - added explanation of how type & extension members are ordered.  Going to tentatively draw a line through alternative algorithms for this.