### PR TITLE
Move spec tests to run on Ruby 3

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 3.0
           bundler-cache: true
       - name: Rubocop
         run: |
@@ -38,7 +38,7 @@ jobs:
           submodules: recursive
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 3.0
           bundler-cache: true
       - name: Cache cocoapods
         uses: actions/cache@v2

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -10,7 +10,7 @@ jobs:
   danger_and_rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1
@@ -33,7 +33,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: ruby/setup-ruby@v1
@@ -41,7 +41,7 @@ jobs:
           ruby-version: 3.1
           bundler-cache: true
       - name: Cache cocoapods
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cocoapods
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.1
           bundler-cache: true
       - name: Rubocop
         run: |
@@ -38,7 +38,7 @@ jobs:
           submodules: recursive
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.1
           bundler-cache: true
       - name: Cache cocoapods
         uses: actions/cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   [#1325](https://github.com/realm/jazzy/issues/1325)
   [John Fairhurst](https://github.com/johnfairh)
 
+* Fix extension ordering in symbolgraph mode.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ## 0.14.3
 
 ##### Breaking

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development do
   gem 'webmock'
 
   # Integration tests
-  gem 'clintegracon', '0.7.0'
+  gem 'clintegracon', git: 'https://github.com/mrackwitz/CLIntegracon.git'
   gem 'diffy'
 
   # Code Review

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,4 +237,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.22
+   2.3.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/mrackwitz/CLIntegracon.git
+  revision: ca88b7b8920b6b6542f9b4ad2b1748855783dbae
+  specs:
+    clintegracon (0.9.0)
+      colored2 (~> 3.1)
+      diffy
+
 PATH
   remote: .
   specs:
@@ -36,9 +44,6 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    clintegracon (0.7.0)
-      colored (~> 1.2)
-      diffy
     cocoapods (1.11.3)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
@@ -76,7 +81,6 @@ GEM
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
-    colored (1.2)
     colored2 (3.1.2)
     concurrent-ruby (1.1.10)
     cork (0.3.0)
@@ -221,7 +225,7 @@ PLATFORMS
 DEPENDENCIES
   bacon
   bundler (~> 2.1)
-  clintegracon (= 0.7.0)
+  clintegracon!
   danger
   diffy
   jazzy!

--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,7 @@ begin
       destination = "spec/integration_specs/#{source.gsub('tmp/', '')}/after"
       if File.exist?(destination)
         sh "rm -rf #{destination}"
-        sh "mv #{source} #{destination}"
+        sh "mv #{source}/transformed #{destination}"
       end
     end
 

--- a/lib/jazzy/symbol_graph.rb
+++ b/lib/jazzy/symbol_graph.rb
@@ -68,7 +68,7 @@ module Jazzy
 
     # Parse the symbol files in the given directory
     def self.parse_symbols(directory)
-      Dir[directory + '/*.symbols.json'].map do |filename|
+      Dir[directory + '/*.symbols.json'].sort.map do |filename|
         # The @ part is for extensions in our module (before the @)
         # of types in another module (after the @).
         File.basename(filename) =~ /(.*?)(@(.*?))?\.symbols/

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -46,7 +46,7 @@ $:.unshift((ROOT + 'spec').to_s)
 require 'rubygems'
 require 'bundler/setup'
 require 'pretty_bacon'
-require 'colored'
+require 'colored2'
 require 'CLIntegracon'
 
 require 'cocoapods'
@@ -66,8 +66,8 @@ CLIntegracon.configure do |c|
   # Ignore certain OSX files
   c.ignores '.DS_Store'
   c.ignores '.git'
-  c.ignores %r{^(?!((api-)?docs/|execution_output.txt))}
-  c.ignores '*.tgz'
+  c.ignores %r{^(?!((api-)?docs(/|\z)|execution_output.txt))}
+  c.ignores '**/*.tgz'
 
   # Remove absolute paths from output
   c.transform_produced '**/undocumented.json' do |path|
@@ -79,6 +79,9 @@ CLIntegracon.configure do |c|
       ).gsub(
         c.spec_path.to_s,
         '<SPEC>',
+      ).gsub(
+        '/transformed',
+        '',
       ),
     )
   end
@@ -114,6 +117,8 @@ describe_cli 'jazzy' do
     s.replace_pattern(/202[\d.:\- ]+xcodebuild.*?\n/, '')
     # Xcode 14 / in-proc sourcekitd workaround
     s.replace_pattern(/<unknown>:0: remark.*?\n/, '')
+    # CLIntegracon 0.8
+    s.replace_pattern(%r{/transformed/}, '/')
   end
 
   require 'shellwords'


### PR DESCRIPTION
Ruby has been doing a painful change to how keyword arguments are passed.

Whatever, there’s a breaking change in Ruby 3 which I want to support for dev purposes to avoid requiring increasingly unsupported versions.

CLIntegracon which is borderline unsupported itself is a victim of this change.  Cocoapods is probably the only other serious user and has got a fix into CLIntegracon trunk.  Thanks Sam G again.

This PR picks up that latest CLIntegracon in the same way as Cocoapods has done.  This ends up jumping quite a few dozen commits requiring some (maddeningly) subtle changes to our driver.

There’s one test output change caused by a weird interaction between `swift-driver` and CLIntegracon — the new version is better, it looks like previously some user-facing output mysteriously vanished.