### PR TITLE
Fix symbolgraph crash with tuple constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 * Fix extension ordering in symbolgraph mode.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Fix symbolgraph mode crash involving tuple generic constraints.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ## 0.14.3
 
 ##### Breaking

--- a/lib/jazzy/symbol_graph/constraint.rb
+++ b/lib/jazzy/symbol_graph/constraint.rb
@@ -70,8 +70,13 @@ module Jazzy
         end.compact
       end
 
-      # Workaround Swift 5.3 bug with missing constraint rels
+      # Workaround Swift 5.3 bug with missing constraint rels, eg.
+      # extension P {
+      #   func f<C>(a: C) where C: P {}
+      # }
       def self.new_list_from_declaration(decl)
+        return [] if decl.include?('(')
+
         decl.split(/\s*,\s*/).map { |cons| Constraint.new_declaration(cons) }
       end
 


### PR DESCRIPTION
The example given of generating docs for `Combine` has started failing - to do with a workaround for a symgraph bug/weirdness.  This disables the workaround when a `where` clause includes tuple types that are too complicated to parse simply.