### PR TITLE
Move CI to macOS 13 / Xcode 14.3

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -25,13 +25,13 @@ jobs:
           bundle exec danger --verbose
 
   spec:
-    runs-on: macos-12
+    runs-on: macos-13
     continue-on-error: true
     strategy:
       matrix:
         spec: ["objc_spec", "swift_spec", "cocoapods_spec"]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - ./spec/integration_specs/**/*
+    - ./spec/Moya.podspec
     - ./vendor/**/*
     - ./tmp/**/*
     - ./SourceKitten/**/*

--- a/spec/Moya.podspec
+++ b/spec/Moya.podspec
@@ -1,0 +1,55 @@
+Pod::Spec.new do |s|
+  s.name         = "Moya"
+  s.version      = "15.0.0"
+  s.summary      = "Network abstraction layer written in Swift"
+  s.description  = <<-EOS
+  Moya abstracts network commands using Swift Generics to provide developers
+  with more compile-time confidence.
+
+  ReactiveSwift and RxSwift extensions exist as well. Instructions for installation
+  are in [the README](https://github.com/Moya/Moya).
+  EOS
+  s.homepage     = "https://github.com/Moya/Moya"
+  s.license      = { :type => "MIT", :file => "License.md" }
+  s.author             = { "Ash Furrow" => "ash@ashfurrow.com" }
+  s.social_media_url   = "http://twitter.com/ashfurrow"
+  s.ios.deployment_target = '11.0'
+  s.osx.deployment_target = '10.13'
+  s.tvos.deployment_target = '10.0'
+  s.watchos.deployment_target = '3.0'
+  s.source       = { :git => "https://github.com/Moya/Moya.git", :tag => s.version }
+  s.default_subspec = "Core"
+  s.swift_version = '5.3'
+  s.cocoapods_version = '>= 1.4.0'
+
+  s.subspec "Core" do |ss|
+    ss.source_files  = "Sources/Moya/", "Sources/Moya/Plugins/"
+    ss.dependency "Alamofire", "~> 5.0"
+    ss.framework  = "Foundation"
+    s.ios.deployment_target = '11.0'
+    s.osx.deployment_target = '10.13'
+    s.tvos.deployment_target = '10.0'
+    s.watchos.deployment_target = '3.0'
+  end
+
+  s.subspec "Combine" do |ss|
+    ss.source_files  = "Sources/CombineMoya/"
+    ss.dependency "Moya/Core"
+    ss.framework  = "Combine"
+    ss.ios.deployment_target = '13.0'
+    ss.osx.deployment_target = '10.15'
+    ss.tvos.deployment_target = '13.0'
+    ss.watchos.deployment_target = '6.0'
+  end
+
+  s.subspec "ReactiveSwift" do |ss|
+    ss.source_files = "Sources/ReactiveMoya/"
+    ss.dependency "Moya/Core"
+    ss.dependency "ReactiveSwift", "~> 7.0"
+    ss.ios.deployment_target = '11.0'
+    ss.osx.deployment_target = '10.13'
+    ss.tvos.deployment_target = '10.0'
+    ss.watchos.deployment_target = '3.0'
+  end
+
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -249,6 +249,10 @@ describe_cli 'jazzy' do
   end if !spec_subset || spec_subset == 'swift'
 
   describe 'jazzy cocoapods' do
+    # Xcode 14.3 workaround, special podspec
+    podspec_patch = ROOT + 'spec/Moya.podspec'
+    podspec_path = ROOT + 'spec/integration_specs/document_moya_podspec/before'
+    FileUtils.cp_r podspec_patch, podspec_path, remove_destination: true
     configure_cocoapods
     describe 'Creates docs for a podspec with dependencies and subspecs' do
       behaves_like cli_spec 'document_moya_podspec',


### PR DESCRIPTION
Minor Objective-C & symgraph improvements from latest tools.

The Moya project and some of its dependencies haven't updated for the latest Xcode minimum-deployment rules, so I've included a cut-down podspec that still includes a couple of subspecs.  Can remove this when/if Moya gets a working release.