### PR TITLE
Support @_documentation(visibility:) attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   `--swift-build-tool symbolgraph`.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Support Swift `@_documentation(visibility:)` attribute.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ##### Bug Fixes
 
 * Issue a warning instead of crashing on declarations without names.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
   `--swift-build-tool symbolgraph`.  
   [John Fairhurst](https://github.com/johnfairh)
 
-* Support Swift `@_documentation(visibility:)` attribute.  
+* Support Swift `@_documentation(visibility:)` attribute.  Requires
+  `--swift-build-tool spm|xcodebuild`.  
   [John Fairhurst](https://github.com/johnfairh)
 
 ##### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -358,6 +358,10 @@ Note that the `--include` option is applied before the `--exclude` option. For e
 Declarations with a documentation comment containing `:nodoc:` are excluded from the
 documentation.
 
+Declarations with the `@_documentation(visibility:)` attribute are treated as though they
+are written with the given visibility.  This is an alternative to `:nodoc:` that is compatible
+with Apple's DocC.
+
 ### Documentation structure
 
 Jazzy arranges documentation into categories.  The default categories are things

--- a/README.md
+++ b/README.md
@@ -359,8 +359,8 @@ Declarations with a documentation comment containing `:nodoc:` are excluded from
 documentation.
 
 Declarations with the `@_documentation(visibility:)` attribute are treated as though they
-are written with the given visibility.  This is an alternative to `:nodoc:` that is compatible
-with Apple's DocC.
+are written with the given visibility.  You can use this as a replacement for `:nodoc:` as
+part of a transition to Apple's DocC but it is not compatible with Jazzy's symbolgraph mode.
 
 ### Documentation structure
 

--- a/lib/jazzy/source_declaration/access_control_level.rb
+++ b/lib/jazzy/source_declaration/access_control_level.rb
@@ -33,11 +33,13 @@ module Jazzy
       def self.from_doc(doc)
         return AccessControlLevel.internal if implicit_deinit?(doc)
 
-        from_accessibility(doc['key.accessibility']) ||
+        from_documentation_attribute(doc) ||
+          from_accessibility(doc['key.accessibility']) ||
           from_doc_explicit_declaration(doc) ||
           AccessControlLevel.internal # fallback on internal ACL
       end
 
+      # Workaround `deinit` being always technically public
       def self.implicit_deinit?(doc)
         doc['key.name'] == 'deinit' &&
           from_doc_explicit_declaration(doc).nil?
@@ -62,6 +64,13 @@ module Jazzy
         end
 
         send(normalized)
+      end
+
+      # From a @_documentation(visibility:) attribute
+      def self.from_documentation_attribute(doc)
+        if doc['key.annotated_decl'] =~ /@_documentation\(\s*visibility\s*:\s*(\w+)/
+          return from_human_string(Regexp.last_match[1])
+        end
       end
 
       # Define `AccessControlLevel.public` etc.

--- a/lib/jazzy/source_declaration/access_control_level.rb
+++ b/lib/jazzy/source_declaration/access_control_level.rb
@@ -69,7 +69,7 @@ module Jazzy
       # From a @_documentation(visibility:) attribute
       def self.from_documentation_attribute(doc)
         if doc['key.annotated_decl'] =~ /@_documentation\(\s*visibility\s*:\s*(\w+)/
-          return from_human_string(Regexp.last_match[1])
+          from_human_string(Regexp.last_match[1])
         end
       end
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -458,6 +458,13 @@ module Jazzy
       attrs.map { |str| str.gsub(/\)(?!\s*$)/, "\ufe5a") }
     end
 
+    # Keep everything except instructions to us
+    def self.extract_documented_attributes(declaration)
+      extract_attributes(declaration).reject do |attr|
+        attr.start_with?('@_documentation')
+      end
+    end
+
     def self.extract_availability(declaration)
       extract_attributes(declaration, 'available')
     end
@@ -521,7 +528,7 @@ module Jazzy
 
       # @available attrs only in compiler 'interface' style
       extract_availability(doc['key.doc.declaration'] || '')
-        .concat(extract_attributes(annotated_decl_attrs))
+        .concat(extract_documented_attributes(annotated_decl_attrs))
         .push(decl)
         .join("\n")
     end


### PR DESCRIPTION
Although `@_documentation` was added in Swift 5.8, it was broken in SourceKit's printer until 5.9

Will add a test for this when there's a 5.9 Xcode in CI.

e: It turns out that unfortunately the semantics of this are baked into the swift symbolgraph code and the actual attribute itself is entirely omitted from the symbolgraph.  This isn't compatible with how jazzy wants to drive the thing.  Perhaps look again at that in future, but the real point of this PR is to let users continue to use the non-symbolgraph backend while transitioning to DocC.