### PR TITLE
Add support for Swift macro declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
 * Update Javascript: jQuery 3.6.3, KaTeX 0.16.4  
   [John Fairhurst](https://github.com/johnfairh)
 
-* Support Swift 5.9 `package` access control level.  
+* Support Swift `package` access control level.  
+  [John Fairhurst](https://github.com/johnfairh)
+
+* Support documenting Swift macro declarations.  
   [John Fairhurst](https://github.com/johnfairh)
 
 ##### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 * Support Swift `package` access control level.  
   [John Fairhurst](https://github.com/johnfairh)
 
-* Support documenting Swift macro declarations.  
+* Initial support for Swift macro declarations.  Requires
+  `--swift-build-tool symbolgraph`.  
   [John Fairhurst](https://github.com/johnfairh)
 
 ##### Bug Fixes

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -456,6 +456,10 @@ module Jazzy
           jazzy: 'Associated Type',
           dash: 'Alias',
         }.freeze,
+        'source.lang.swift.decl.macro' => {
+          jazzy: 'Macro',
+          dash: 'Macro',
+        }.freeze,
       }.freeze
     end
     # rubocop:enable Metrics/ClassLength

--- a/lib/jazzy/symbol_graph/symbol.rb
+++ b/lib/jazzy/symbol_graph/symbol.rb
@@ -100,6 +100,7 @@ module Jazzy
         'typealias' => 'typealias',
         'associatedtype' => 'associatedtype',
         'actor' => 'actor',
+        'macro' => 'macro',
       }.freeze
 
       # We treat 'static var' differently to 'class var'

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -119,6 +119,8 @@ describe_cli 'jazzy' do
     s.replace_pattern(/<unknown>:0: remark.*?\n/, '')
     # CLIntegracon 0.8
     s.replace_pattern(%r{/transformed/}, '/')
+    # Xcode 15 workaround
+    s.replace_pattern(/objc\[.....\]: Class _?DTX\w+ is implemented in both.*?\n/, '')
   end
 
   require 'shellwords'


### PR DESCRIPTION
Add handling for the 'macro' declaration type.  Dash has a suitable section type.

SourceKit is currently broken for macro decls - apple/swift#66666.  Symgraph works OK.

![Screenshot 2023-06-18 at 11 42 00](https://github.com/realm/jazzy/assets/26768470/813a5912-95bf-495e-8e8b-7eb0605446da)
![Screenshot 2023-06-18 at 11 43 31](https://github.com/realm/jazzy/assets/26768470/7b546b9c-d2d5-46d6-80fd-38a5a5f865b0)

Another problem: doc comments for macro parameters aren't identified properly.  Will wait and see how this changes over the betas before trying to work around.
