### PR TITLE
Move CI to Swift 5.9 / Xcode 15 beta

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         spec: ["objc_spec", "swift_spec", "cocoapods_spec"]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
     steps:
       - uses: actions/checkout@v3
         with:

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -251,13 +251,17 @@ describe_cli 'jazzy' do
   describe 'jazzy cocoapods' do
     # Xcode 14.3 workaround, special podspec
     podspec_patch = ROOT + 'spec/Moya.podspec'
-    podspec_path = ROOT + 'spec/integration_specs/document_moya_podspec/before'
-    FileUtils.cp_r podspec_patch, podspec_path, remove_destination: true
+    podspec_used = ROOT + 'spec/integration_specs/document_moya_podspec/before/Moya.podspec'
+    podspec_save = ROOT + 'spec/Moya.podspec.safe'
+    FileUtils.cp_r podspec_used, podspec_save, remove_destination: true
+    FileUtils.cp_r podspec_patch, podspec_used, remove_destination: true
     configure_cocoapods
     describe 'Creates docs for a podspec with dependencies and subspecs' do
       behaves_like cli_spec 'document_moya_podspec',
                             '--podspec=Moya.podspec'
     end
+    FileUtils.cp_r podspec_save, podspec_used, remove_destination: true
+    FileUtils.rm_rf podspec_save
   end if !spec_subset || spec_subset == 'cocoapods'
 
   # rubocop:enable Style/MultilineIfModifier


### PR DESCRIPTION
Move to Swift 5.9 so I can get tests written for 5.9 features while I have the time.

Specs changes:

**realm objc**
`libdispatch` types not being translated from their ObjC names into their Swift names.
Visible in Xcode 15b2 as well.  Something wrong with the macos SDK in Xcode 15, works fine using Swift 5.9 against a 14.3 sysroot.

**moya/siesta**
_no such module `AppKit` / `UIKit.UIImage`_ reports.
This is due to a Swift 5.9 SourceKit change — if we request cursorinfo for a symbol excluded from compilation by eg. `#if os(iOS)` then Swift attempts to compile that branch of the `#if` a bit harder than earlier, which fails.  Does not affect the actual sourcekit behaviour.

**symgraph**
Better treatment of `@spi` declarations. Things have moved around because previously these things didn’t even get locations; now we know where they should go.
