### PR TITLE
Improving Jazzy Documentation for Multiple Modules

### DIFF
--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -263,6 +263,10 @@ module Jazzy
       description: 'Name of module being documented. (e.g. RealmSwift)',
       default: ''
 
+    config_attr :multiple_modules,
+      command_line: ['--multiple_modules MODULE_NAME1,...ModuleNameN', Array],
+      description: 'Name of modules being documented. (e.g. RealmSwift,...)'
+
     config_attr :version,
       command_line: '--module-version VERSION',
       description: 'Version string to use as part of the default docs ' \

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -178,12 +178,9 @@ module Jazzy
         'sourcekitten.',
       default: []
 
-    config_attr :custom_modules,
-      # command_line: ['-cm', '--build-tool-arguments arg1,arg2,…argN', NArray],
-      description: 'Custom navigation categories to replace the standard ' \
-        "'Classes', 'Protocols', etc. Types not explicitly named " \
-        'in a custom category appear in generic groups at the ' \
-        'end.  Example: https://git.io/v4Bcp',
+    config_attr :modules,
+      description: 'Array of modules that are going to be documented ' \
+      'It will contain arguments:  - name, build-tool-arguments arg1,arg2,…argN, source_directory.',
       default: false
 
     alias_config_attr :xcodebuild_arguments, :build_tool_arguments,
@@ -271,10 +268,6 @@ module Jazzy
       command_line: ['-m', '--module MODULE_NAME'],
       description: 'Name of module being documented. (e.g. RealmSwift)',
       default: ''
-
-    config_attr :modules,
-      command_line: ['--modules MODULE_NAME1,...ModuleNameN', Array],
-      description: 'Name of module being documented. (e.g. RealmSwift)'
 
     config_attr :version,
       command_line: '--module-version VERSION',
@@ -586,6 +579,7 @@ module Jazzy
         self.class.all_config_attrs.group_by(&prop)
       end
 
+
       config_file.each do |key, value|
         unless attr = attrs_by_conf_key[key]
           message = "Unknown config file attribute #{key.inspect}"
@@ -596,7 +590,6 @@ module Jazzy
           warning message
           next
         end
-
         attr.first.set_if_unconfigured(self, value)
       end
 
@@ -618,8 +611,9 @@ module Jazzy
           '`framework_root` or `umbrella_header` may be ignored.'
       end
 
-      if custom_modules_configured && module_name_configured
-        raise 'Usage of config and comand line'
+      if modules_configured && module_name_configured
+        raise 'Jazzy only allows the use of a single command for generating documentation.' \
+        'Using both module configuration and modules configuration together is not supported.'
       end
     end
 
@@ -632,7 +626,6 @@ module Jazzy
         candidate = dir.join('.jazzy.yaml')
         return candidate if candidate.exist?
       end
-
       nil
     end
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -263,8 +263,8 @@ module Jazzy
       description: 'Name of module being documented. (e.g. RealmSwift)',
       default: ''
 
-    config_attr :multiple_modules,
-      command_line: ['--multiple_modules MODULE_NAME1,...ModuleNameN', Array],
+    config_attr :modules,
+      command_line: ['--modules MODULE_NAME1,...ModuleNameN', Array],
       description: 'Name of modules being documented. (e.g. RealmSwift,...)'
 
     config_attr :version,
@@ -522,6 +522,17 @@ module Jazzy
 
       config
     end
+
+    def self.module_configuration(directory)
+      config = new
+      config.source_directory = directory
+      config.parse_config_file
+ 
+      config.validate
+ 
+      config
+    end
+
 
     def warning(message)
       warn "WARNING: #{message}"

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -51,6 +51,7 @@ module Jazzy
       end
 
       def attach_to_option_parser(config, opt)
+        
         return if command_line.empty?
 
         opt.on(*command_line, *description) do |val|
@@ -177,6 +178,14 @@ module Jazzy
         'sourcekitten.',
       default: []
 
+    config_attr :custom_modules,
+      # command_line: ['-cm', '--build-tool-arguments arg1,arg2,…argN', NArray],
+      description: 'Custom navigation categories to replace the standard ' \
+        "'Classes', 'Protocols', etc. Types not explicitly named " \
+        'in a custom category appear in generic groups at the ' \
+        'end.  Example: https://git.io/v4Bcp',
+      default: false
+
     alias_config_attr :xcodebuild_arguments, :build_tool_arguments,
       command_line: ['-x', '--xcodebuild-arguments arg1,arg2,…argN', Array],
       description: 'Back-compatibility alias for build_tool_arguments.'
@@ -265,7 +274,7 @@ module Jazzy
 
     config_attr :modules,
       command_line: ['--modules MODULE_NAME1,...ModuleNameN', Array],
-      description: 'Name of modules being documented. (e.g. RealmSwift,...)'
+      description: 'Name of module being documented. (e.g. RealmSwift)'
 
     config_attr :version,
       command_line: '--module-version VERSION',
@@ -517,22 +526,11 @@ module Jazzy
           "docsets/#{config.module_name}.xml",
         )
       end
-
+      
       config.validate
 
       config
     end
-
-    def self.module_configuration(directory)
-      config = new
-      config.source_directory = directory
-      config.parse_config_file
- 
-      config.validate
- 
-      config
-    end
-
 
     def warning(message)
       warn "WARNING: #{message}"
@@ -618,6 +616,10 @@ module Jazzy
          (framework_root_configured || umbrella_header_configured)
         warning 'Option `build_tool_arguments` is set: values passed to ' \
           '`framework_root` or `umbrella_header` may be ignored.'
+      end
+
+      if custom_modules_configured && module_name_configured
+        raise 'Usage of config and comand line'
       end
     end
 

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -76,38 +76,27 @@ module Jazzy
         stdout = pod_documenter.sourcekitten_output(options)
       elsif options.swift_build_tool == :symbolgraph
         stdout = SymbolGraph.build(options)
-      elsif options.multiple_modules_configured
+      elsif options.modules_configured
         modules_parsed = Array[]
-        options.multiple_modules.each do |directory|
-          if options.build_tool_arguments_configured 
-            replace_scheme_name_for_new_module(options)
-            build_options = options.build_tool_arguments
-            build_options.push(directory)
-            options.build_tool_arguments = build_options
-          end
+        options.modules.each do |directory|
           directory = options.source_directory + directory
-          module_parsed_string = run_xcode(directory, options)
+          module_options = Config.module_configuration(directory)
+          module_parsed_string = run_xcode(module_options)
           modules_parsed.push(module_parsed_string)
         end
         stdout = "[#{modules_parsed.join(',')}]"
       else
-        stdout = run_xcode(options.source_directory, options)
+        stdout = run_xcode(options)
       end
       build_docs_for_sourcekitten_output(stdout, options)
-    end
-
-    def self.replace_scheme_name_for_new_module(options)
-      if options.build_tool_arguments.count > 3 
-        options.build_tool_arguments.pop()
-      end
     end
 
     # Build Xcode project and parse the api documentation into a string
     # @param [String] source_directory where xcode project is
     # @param [Config] options
     # @return [String] the documented source module
-    def self.run_xcode(sourceDirectory, options)
-      Dir.chdir(sourceDirectory) do
+    def self.run_xcode(options)
+      Dir.chdir(options.source_directory) do
         arguments = SourceKitten.arguments_from_options(options)
         SourceKitten.run_sourcekitten(arguments)
       end

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -69,7 +69,6 @@ module Jazzy
     # @param [Config] options
     # @return [SourceModule] the documented source module
     def self.build(options)
-      # binding.pry
       if options.modules_configured
         stdout = multiple_modules(options)
       elsif options.sourcekitten_sourcefile_configured
@@ -91,10 +90,9 @@ module Jazzy
 
     def self.multiple_modules(options)
       modules_parsed = Array[]
-      # binding.pry
       options.custom_modules.each do |arguments|
         module_parsed_string = Dir.chdir(arguments['source_directory']) do
-          arguments = SourceKitten.arguments_from_options(options) + arguments['build_tool_arguments']
+          arguments = SourceKitten.arguments_from_options(options) + (arguments['build_tool_arguments']||[])
           SourceKitten.run_sourcekitten(arguments)
         end
         modules_parsed.push(module_parsed_string)

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -88,9 +88,12 @@ module Jazzy
       build_docs_for_sourcekitten_output(stdout, options)
     end
 
+    # Build Xcode project for multiple modules and parse the api documentation into a string
+    # @param [Config] options
+    # @return String the documented source module
     def self.multiple_modules(options)
       modules_parsed = Array[]
-      options.custom_modules.each do |arguments|
+      options.modules.each do |arguments|
         module_parsed_string = Dir.chdir(arguments['source_directory']) do
           arguments = SourceKitten.arguments_from_options(options) + (arguments['build_tool_arguments']||[])
           SourceKitten.run_sourcekitten(arguments)
@@ -98,17 +101,6 @@ module Jazzy
         modules_parsed.push(module_parsed_string)
       end
       stdout = "[#{modules_parsed.join(',')}]"
-    end
-
-    # Build Xcode project and parse the api documentation into a string
-    # @param [String] source_directory where xcode project is
-    # @param [Config] options
-    # @return [String] the documented source module
-    def self.run_xcode(options, directory)
-      Dir.chdir(directory) do
-        arguments = SourceKitten.arguments_from_options(options)
-        SourceKitten.run_sourcekitten(arguments)
-      end
     end
 
     # Build & write HTML docs to disk from structured docs array

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -70,10 +70,13 @@ module Jazzy
       custom_categories + merge_categories(type_categories) + uncategorized
     end
 
+    # Group root-level docs by module name
     def self.group_docs_per_module(docs, modules)
+      modules = modules.map { |mod| mod['name']}
       categories, extra = navigation_module_section(
         docs, modules
       )
+
       merge_categories(categories) + self.group_docs(extra)
     end
 
@@ -108,15 +111,12 @@ module Jazzy
     end
 
     def self.navigation_module_section(docs, modules)
-      # binding.pry
       group = modules.map do |modulename|
-        moduleN = modulename
-        children, docs = docs.partition { |doc| doc.modulename == moduleN }
-          
+        children, docs = docs.partition { |doc| doc.modulename == modulename }
         make_group(
           children,
           modulename,
-          "Find a way to add the correct abstract for each module",
+          "",
         )
       end
 
@@ -268,7 +268,7 @@ module Jazzy
         arguments += ['--']
       end
       
-      if options.custom_modules_configured
+      if options.modules_configured
         arguments
       else 
         arguments + options.build_tool_arguments
@@ -299,7 +299,6 @@ module Jazzy
 
     # Run sourcekitten with given arguments and return STDOUT
     def self.run_sourcekitten(arguments)
-      
       if swift_version = Config.instance.swift_version
         unless xcode = XCInvoke::Xcode.find_swift_version(swift_version)
           raise "Unable to find an Xcode with swift version #{swift_version}."
@@ -1143,12 +1142,11 @@ module Jazzy
       # than min_acl
       docs = docs.reject { |doc| doc.type.swift_enum_element? }
       ungrouped_docs = docs
-      # if options.modules_configured
-      
+      if options.modules_configured
         docs = group_docs_per_module(docs, options.modules)
-      # else
-        # docs = group_docs(docs)
-      # end
+      else
+        docs = group_docs(docs)
+      end
       
       merge_consecutive_marks(docs)
       make_doc_urls(docs)

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -110,7 +110,7 @@ module Jazzy
     def self.navigation_module_section(docs, modules)
       # binding.pry
       group = modules.map do |modulename|
-        moduleN = "TomTomSDK" + modulename
+        moduleN = modulename
         children, docs = docs.partition { |doc| doc.modulename == moduleN}
         make_group(
           children,


### PR DESCRIPTION
This pull request introduces enhancements to the Jazzy documentation tool, specifically focusing on supporting multiple modules within Xcode projects or workspaces.

To summarize the changes made:

* New Command Line Attribute: A new command line attribute called "**modules**" has been added. This attribute allows users to specify multiple module names when generating documentation using Jazzy.
Usage example:
`jazzy --modules ModuleName1,ModuleName2,...,ModuleNameN`

* Support for Workspace-based projects: If you have multiple Xcode projects that can only be successfully built using a workspace, follow these steps:

a. Each module should have its own configuration file with "**xcodebuild_arguments**" specified

Usage example:
`jazzy --modules ModuleName1,ModuleName2,...,ModuleNameN`

Proposal PR: https://github.com/realm/jazzy/pull/1363

