### PR TITLE
Correct activesupport usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix incorrect activesupport usage.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ## 0.14.4
 

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/inflector'
 
 module Jazzy


### PR DESCRIPTION
Per activesupport gem usage instructions.

There's no actual problem being fixed here, but cocoapods got hit by a similar mistake with very bad consequences, see #1370.

(Our CI runs jazzy via bundler so uses the known-good gem versions rather than the latest versions of everything which is why it does not see the cocoapods issue.)