### PR TITLE
Symbolgraph extension symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Enhancements
 
-* None.
+* Support Swift 5.9 symbolgraph extension symbols.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1368](https://github.com/realm/jazzy/issues/1368)
 
 ##### Bug Fixes
 

--- a/lib/jazzy/symbol_graph.rb
+++ b/lib/jazzy/symbol_graph.rb
@@ -7,6 +7,7 @@ require 'jazzy/symbol_graph/symbol'
 require 'jazzy/symbol_graph/relationship'
 require 'jazzy/symbol_graph/sym_node'
 require 'jazzy/symbol_graph/ext_node'
+require 'jazzy/symbol_graph/ext_key'
 
 # This is the top-level symbolgraph driver that deals with
 # figuring out arguments, running the tool, and loading the
@@ -72,10 +73,12 @@ module Jazzy
         # The @ part is for extensions in our module (before the @)
         # of types in another module (after the @).
         File.basename(filename) =~ /(.*?)(@(.*?))?\.symbols/
-        module_name = Regexp.last_match[3] || Regexp.last_match[1]
+        module_name = Regexp.last_match[1]
+        ext_module_name = Regexp.last_match[3] || module_name
+        json = File.read(filename)
         {
           filename =>
-            Graph.new(File.read(filename), module_name).to_sourcekit,
+            Graph.new(json, module_name, ext_module_name).to_sourcekit,
         }
       end.to_json
     end

--- a/lib/jazzy/symbol_graph/ext_key.rb
+++ b/lib/jazzy/symbol_graph/ext_key.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Jazzy
+  module SymbolGraph
+    # An ExtKey identifies an extension of a type, made up of the USR of
+    # the type and the constraints of the extension.  With Swift 5.9 extension
+    # symbols, the USR is the 'fake' USR invented by symbolgraph to solve the
+    # same problem as this type, which means less merging takes place.
+    class ExtKey
+      attr_accessor :usr
+      attr_accessor :constraints_text
+
+      def initialize(usr, constraints)
+        self.usr = usr
+        self.constraints_text = constraints.map(&:to_swift).join
+      end
+
+      def hash_key
+        usr + constraints_text
+      end
+
+      def eql?(other)
+        hash_key == other.hash_key
+      end
+
+      def hash
+        hash_key.hash
+      end
+    end
+
+    class ExtSymNode
+      def ext_key
+        ExtKey.new(usr, all_constraints.ext)
+      end
+    end
+  end
+end

--- a/lib/jazzy/symbol_graph/sym_node.rb
+++ b/lib/jazzy/symbol_graph/sym_node.rb
@@ -18,8 +18,8 @@ module Jazzy
         children.append(child)
       end
 
-      def children_to_sourcekit
-        children.sort.map(&:to_sourcekit)
+      def children_to_sourcekit(module_name)
+        children.sort.map { |c| c.to_sourcekit(module_name) }
       end
     end
 
@@ -129,7 +129,7 @@ module Jazzy
       end
 
       # rubocop:disable Metrics/MethodLength
-      def to_sourcekit
+      def to_sourcekit(module_name)
         declaration = full_declaration
         xml_declaration = "<swift>#{CGI.escapeHTML(declaration)}</swift>"
 
@@ -137,8 +137,9 @@ module Jazzy
           'key.kind' => symbol.kind,
           'key.usr' => symbol.usr,
           'key.name' => symbol.name,
+          'key.modulename' => module_name,
           'key.accessibility' => symbol.acl,
-          'key.parsed_decl' => declaration,
+          'key.parsed_declaration' => declaration,
           'key.annotated_decl' => xml_declaration,
           'key.symgraph_async' => async?,
         }
@@ -156,7 +157,7 @@ module Jazzy
           hash['key.doc.column'] = location[:character] + 1
         end
         unless children.empty?
-          hash['key.substructure'] = children_to_sourcekit
+          hash['key.substructure'] = children_to_sourcekit(module_name)
         end
         hash['key.symgraph_spi'] = true if symbol.spi
 

--- a/lib/jazzy/symbol_graph/sym_node.rb
+++ b/lib/jazzy/symbol_graph/sym_node.rb
@@ -18,14 +18,16 @@ module Jazzy
         children.append(child)
       end
 
-      def children_to_sourcekit(module_name)
-        children.sort.map { |c| c.to_sourcekit(module_name) }
+      def add_children_to_sourcekit(hash, module_name)
+        unless children.empty?
+          hash['key.substructure'] =
+            children.sort.map { |c| c.to_sourcekit(module_name) }
+        end
       end
     end
 
     # A SymNode is a node of the reconstructed syntax tree holding a symbol.
     # It can turn itself into SourceKit and helps decode extensions.
-    # rubocop:disable Metrics/ClassLength
     class SymNode < BaseNode
       attr_accessor :symbol
       attr_writer :override
@@ -128,7 +130,6 @@ module Jazzy
           .join("\n")
       end
 
-      # rubocop:disable Metrics/MethodLength
       def to_sourcekit(module_name)
         declaration = full_declaration
         xml_declaration = "<swift>#{CGI.escapeHTML(declaration)}</swift>"
@@ -138,32 +139,19 @@ module Jazzy
           'key.usr' => symbol.usr,
           'key.name' => symbol.name,
           'key.modulename' => module_name,
-          'key.accessibility' => symbol.acl,
           'key.parsed_declaration' => declaration,
           'key.annotated_decl' => xml_declaration,
           'key.symgraph_async' => async?,
         }
-        if docs = symbol.doc_comments
-          hash['key.doc.comment'] = docs
-          hash['key.doc.full_as_xml'] = ''
-        end
         if params = symbol.parameter_names
           hash['key.doc.parameters'] =
             params.map { |name| { 'name' => name } }
         end
-        if location = symbol.location
-          hash['key.filepath'] = location[:filename]
-          hash['key.doc.line'] = location[:line] + 1
-          hash['key.doc.column'] = location[:character] + 1
-        end
-        unless children.empty?
-          hash['key.substructure'] = children_to_sourcekit(module_name)
-        end
         hash['key.symgraph_spi'] = true if symbol.spi
 
-        hash
+        add_children_to_sourcekit(hash, module_name)
+        symbol.add_to_sourcekit(hash)
       end
-      # rubocop:enable Metrics/MethodLength
 
       # Sort order - by symbol
       include Comparable
@@ -172,6 +160,5 @@ module Jazzy
         symbol <=> other.symbol
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/jazzy/symbol_graph/symbol.rb
+++ b/lib/jazzy/symbol_graph/symbol.rb
@@ -226,6 +226,25 @@ module Jazzy
           availability_attributes(avail_hash_list) + spi_attributes
       end
 
+      # SourceKit common fields, shared by extension and regular symbols.
+      # Things we do not know for fabricated extensions.
+      def add_to_sourcekit(hash)
+        unless doc_comments.nil?
+          hash['key.doc.comment'] = doc_comments
+          hash['key.doc.full_as_xml'] = ''
+        end
+
+        hash['key.accessibility'] = acl
+
+        unless location.nil?
+          hash['key.filepath'] = location[:filename]
+          hash['key.doc.line'] = location[:line] + 1
+          hash['key.doc.column'] = location[:character] + 1
+        end
+
+        hash
+      end
+
       # Sort order
       include Comparable
 

--- a/lib/jazzy/symbol_graph/symbol.rb
+++ b/lib/jazzy/symbol_graph/symbol.rb
@@ -22,6 +22,10 @@ module Jazzy
         path_components[-1] || '??'
       end
 
+      def full_name
+        path_components.join('.')
+      end
+
       def initialize(hash)
         self.usr = hash[:identifier][:precise]
         self.path_components = hash[:pathComponents]
@@ -101,6 +105,7 @@ module Jazzy
         'associatedtype' => 'associatedtype',
         'actor' => 'actor',
         'macro' => 'macro',
+        'extension' => 'extension',
       }.freeze
 
       # We treat 'static var' differently to 'class var'
@@ -120,6 +125,10 @@ module Jazzy
         raise "Unknown symbol kind '#{kind}'" unless sourcekit_kind
 
         self.kind = "source.lang.swift.decl.#{sourcekit_kind}"
+      end
+
+      def extension?
+        kind.end_with?('extension')
       end
 
       # Mapping SymbolGraph's ACL to SourceKit

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -246,7 +246,8 @@ describe_cli 'jazzy' do
       module_path = `swift build --scratch-path #{build_path} --show-bin-path`
       behaves_like cli_spec 'misc_jazzy_symgraph_features',
                             '--swift-build-tool symbolgraph ' \
-                              "--build-tool-arguments -I,#{module_path} "
+                              '--build-tool-arguments ' \
+                              "-emit-extension-block-symbols,-I,#{module_path}"
     end
   end if !spec_subset || spec_subset == 'swift'
 


### PR DESCRIPTION
Support the opt-in symbolgraph extension symbols for Swift 5.9.

These are for extensions from other modules only, extensions in the same module don't get these symbols.  I've turned on the option for the test case because it runs on Swift 5.9 and exercises all the new paths -- looks good, grabs a bunch more information for those extensions including doc comments.