### PR TITLE
Restore Ruby 2.6 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Restore compatibility with Ruby 2.6  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1388](https://github.com/realm/jazzy/issues/1388)
 
 ## 0.15.0
 

--- a/lib/jazzy/config.rb
+++ b/lib/jazzy/config.rb
@@ -717,12 +717,12 @@ module Jazzy
 
       if modules.first.is_a?(String)
         # Massage format (2) into (3)
-        self.modules = modules.map { { 'module' => _1 } }
+        self.modules = modules.map { |mod| { 'module' => mod } }
       end
 
       # Allow per-module overrides of only some config options
       attrs_by_conf_key, attrs_by_name =
-        grouped_attributes { _1.select(&:per_module) }
+        grouped_attributes { |attr| attr.select(&:per_module) }
 
       modules.map do |module_hash|
         mod_name = module_hash['module'] || ''

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -692,7 +692,7 @@ module Jazzy
       decl.type.objc_class? ||
         (decl.type.objc_category? &&
           (category_classname = decl.objc_category_name[0]) &&
-          root_decls.any? { _1.name == category_classname })
+          root_decls.any? { |d| d.name == category_classname })
     end
 
     # Returns if a Swift declaration is mergeable.
@@ -919,7 +919,9 @@ module Jazzy
 
     # Grab all the extensions from the same doc module
     def self.next_doc_module_group(decls)
-      decls.partition { _1.doc_module_name == decls.first.doc_module_name }
+      decls.partition do |decl|
+        decl.doc_module_name == decls.first.doc_module_name
+      end
     end
 
     # Does this extension/type need a note explaining which doc module it is from?
@@ -1055,12 +1057,12 @@ module Jazzy
     # Remove top-level enum cases because it means they have an ACL lower
     # than min_acl
     def self.reject_swift_types(docs)
-      docs.reject { _1.type.swift_enum_element? }
+      docs.reject { |doc| doc.type.swift_enum_element? }
     end
 
     # Spot and mark any categories on classes not declared in these docs
     def self.mark_objc_external_categories(docs)
-      class_names = docs.select { _1.type.objc_class? }.to_set(&:name)
+      class_names = docs.select { |doc| doc.type.objc_class? }.to_set(&:name)
 
       docs.map do |doc|
         if (names = doc.objc_category_name) && !class_names.include?(names.first)


### PR DESCRIPTION
Fix code that accidentally uses Ruby 2.7 features.

Built the specs with this on Ruby 2.6.10 - all fine, slightly different to (=worse than) current because of Rouge versions.

Fixes #1388.