### PR TITLE
Updates for Swift 6

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '16.0-beta'
@@ -42,7 +43,7 @@ jobs:
           ruby-version: 3.2
           bundler-cache: true
       - name: Cache cocoapods
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cocoapods
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -36,7 +36,7 @@ jobs:
           submodules: recursive
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 15.3
+          xcode-version: '16.0-beta'
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.0-beta'
+          xcode-version: '16.0'
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Support Swift 6.0 / Xcode 16.0  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ##### Bug Fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 15.3 installed to build the integration specs.
+You must have Xcode 16.0 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/lib/jazzy/podspec_documenter.rb
+++ b/lib/jazzy/podspec_documenter.rb
@@ -102,7 +102,7 @@ module Jazzy
     private_class_method :github_file_prefix
 
     # Latest valid value for SWIFT_VERSION.
-    LATEST_SWIFT_VERSION = '5'
+    LATEST_SWIFT_VERSION = '6'
 
     # All valid values for SWIFT_VERSION that are longer
     # than a major version number.  Ordered ascending.

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -485,8 +485,17 @@ module Jazzy
       # @available attrs only in compiler 'interface' style
       extract_availability(doc['key.doc.declaration'] || '')
         .concat(extract_documented_attributes(annotated_decl_attrs))
+        .concat(fabricate_spi_attributes(doc, annotated_decl_attrs))
         .push(decl)
         .join("\n")
+    end
+
+    # Swift 6 workaround: @_spi attribute & SPI group missing
+    def self.fabricate_spi_attributes(doc, attrs)
+      return [] unless spi_attribute?(doc)
+      return [] if attrs =~ /@_spi/
+
+      ['@_spi(<<unknown>>)']
     end
 
     # Exclude non-async routines that accept async closures

--- a/lib/jazzy/symbol_graph/relationship.rb
+++ b/lib/jazzy/symbol_graph/relationship.rb
@@ -34,7 +34,7 @@ module Jazzy
       # Protocol conformances added by compiler to actor decls that
       # users aren't interested in.
       def actor_protocol?
-        %w[Actor Sendable].include?(target_fallback)
+        %w[Actor AnyActor Sendable].include?(target_fallback)
       end
 
       def initialize(hash)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -249,7 +249,8 @@ describe_cli 'jazzy' do
       behaves_like cli_spec 'misc_jazzy_symgraph_features',
                             '--swift-build-tool symbolgraph ' \
                               '--build-tool-arguments ' \
-                              "-emit-extension-block-symbols,-I,#{module_path}"
+                              '-emit-extension-block-symbols,-I,' \
+                              "#{module_path.chomp}/Modules"
     end
 
     describe 'Creates docs for a multiple-module project' do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -146,6 +146,15 @@ describe_cli 'jazzy' do
 </script>
   HTML
 
+  realm_jazzy_yaml = <<-YAML
+build_tool_arguments:
+  - "-scheme"
+  - "RealmSwift"
+  - "SWIFT_VERSION=4.2"
+  - "-destination"
+  - "platform=OS X,arch=x86_64"
+  YAML
+
   spec_subset = ENV.fetch('JAZZY_SPEC_SUBSET', nil)
 
   # rubocop:disable Style/MultilineIfModifier
@@ -208,9 +217,15 @@ describe_cli 'jazzy' do
 
     describe 'Creates Realm Swift docs' do
       realm_version = ''
-      Dir.chdir(ROOT + 'spec/integration_specs/document_realm_swift/before') do
+      realm_path = ROOT + 'spec/integration_specs/document_realm_swift/before'
+      realm_jazzy_path = realm_path + '.jazzy.yaml'
+
+      Dir.chdir(realm_path) do
         realm_version = `./build.sh get-version`.chomp
       end
+      # Xcode 16 workaround
+      File.write(realm_jazzy_path, realm_jazzy_yaml)
+
       behaves_like cli_spec 'document_realm_swift',
                             '--author Realm ' \
                               '--author_url "https://realm.io" ' \
@@ -222,10 +237,8 @@ describe_cli 'jazzy' do
                               "--module-version #{realm_version} " \
                               '--root-url https://realm.io/docs/swift/' \
                               "#{realm_version}/api/ " \
-                              '--xcodebuild-arguments ' \
-                              '-scheme,RealmSwift,SWIFT_VERSION=4.2,' \
-                              "-destination,'platform=OS X' " \
                               "--head #{realm_head.shellescape}"
+      FileUtils.rm_rf realm_jazzy_path
     end
 
     describe 'Creates Siesta docs' do


### PR DESCRIPTION
Code changes:
* SourceKit has broken SPI group extraction, have to fake it.
* SymGraph is generating duplicate conformances, have to uniq them.
* At some point `Actor` protocol changed to `AnyActor`
* SwiftPM moved the built module into a `Modules` directory…

Spec changes:
* Alamofire, RealmSwift - attribute ordering has been changed, in particular `@autoclosure` and `@escaping` have been reversed; more types are marked `@MainActor`.
* RealmObjC - many fewer symbols but these are all in “_private” header files eg. `RLMAppSubscriptionToken`, `RLMUpdatePolicy`.  I think Clang must have improved to respect an #ifdef or something.  Result is better.
* Moved jazzy test projects to require Swift 6