### PR TITLE
[#1400] Group global constants and functions by file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Enhancements
 
-* None.
+* Group global constants and functions by file name.\
+  [Pushkar Sharma](https://github.com/thepsguy)
+  [#1400](https://github.com/realm/jazzy/issues/1400)
 
 ##### Bug Fixes
 

--- a/lib/jazzy/doc_index.rb
+++ b/lib/jazzy/doc_index.rb
@@ -69,12 +69,30 @@ module Jazzy
         [self] +
           (children[parts.first]&.lookup_path(parts[1...]) || [])
       end
+
+      include Enumerable
+
+      def each(&block)
+        return to_enum(:each) unless block_given?
+
+        block.call(decl) if decl
+
+        children.each do |index_name, scope|
+          scope.each(&block) unless index_name.include?('...')
+        end
+      end
     end
 
     attr_reader :root_scope
 
     def initialize(all_decls)
       @root_scope = Scope.new_root(all_decls.group_by(&:module_name))
+    end
+
+    include Enumerable
+
+    def each(&block)
+      root_scope.each(&block)
     end
 
     # Look up a name and return the matching SourceDeclaration or nil.


### PR DESCRIPTION
- Make `doc_index` iterable.
- After `custom_categories` are processed, group any remaining global constants / functions further based on the file they're in.

Staged sample: https://serve-dot-zipline.appspot.com/asset/55d078ae-b243-597e-9a9d-257f931f2723/zpc/63fc25cv8le/GMSGeometryUtils%2BFunctions.html

Resolves #1400 