### PR TITLE
Updates for Swift 6.1

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -25,7 +25,7 @@ jobs:
           bundle exec danger --verbose
 
   spec:
-    runs-on: macos-14
+    runs-on: macos-15
     continue-on-error: true
     strategy:
       matrix:
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.0'
+          xcode-version: '16.3'
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Don't call extension members that do not need documentation
+  'undocumented'.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ## 0.15.3
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ git push
 You'll need push access to the integration specs repo to do this. You can
 request access from one of the maintainers when filing your PR.
 
-You must have Xcode 16.0 installed to build the integration specs.
+You must have Xcode 16.3 installed to build the integration specs.
 
 ## Making changes to SourceKitten
 

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -831,8 +831,12 @@ module Jazzy
         wanted_exts = []
       end
 
-      # Don't tell the user to document them
-      unwanted_exts.each { |e| @stats.remove_undocumented(e) }
+      # Don't tell the user to document them or their contents
+      remover = lambda do |decls|
+        decls.each { |d| @stats.remove_undocumented(d) }
+        decls.map(&:children).each { |c| remover[c] }
+      end
+      remover[unwanted_exts]
 
       objc_exts + wanted_exts
     end


### PR DESCRIPTION
alamofire
* Undocumented% changes for unclear reason, perhaps how Swift is handling #ifdefs again 

document_realm_objc
* Libclang NS_SWIFT_NAME on properties loses the property name...
![Screenshot 2025-04-29 at 09 46 40](https://github.com/user-attachments/assets/ccaecbfe-cadc-490b-8092-83aeae2ba64a)


document_realm_swift
* Found an actual bug here - something changed in Swift that showed we were calling out things as undocumented that didn’t need documentation.  Public things in an extension of an internal protocol should *not* be called ‘undocumented’ but we don’t know that until very late on in the game, so first call them undocumented & then rescind.  But we don’t do that for the extension members, just the extension itself.

misc_jazzy_symgraph_features
* Improved Swift decls