### PR TITLE
Work around activesupport logger bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   'undocumented'.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Work around activesupport vs. concurrent-ruby crash.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1414](https://github.com/realm/jazzy/issues/1414)
+
 ## 0.15.3
 
 ##### Breaking

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,9 @@ PATH
   remote: .
   specs:
     jazzy (0.15.3)
+      activesupport (>= 5.0, < 8)
       cocoapods (~> 1.5)
+      logger
       mustache (~> 1.1)
       open4 (~> 1.3)
       redcarpet (~> 3.4)

--- a/jazzy.gemspec
+++ b/jazzy.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/)
   spec.executables << 'jazzy'
 
+  spec.add_dependency 'activesupport', '>= 5.0', '< 8'
   spec.add_dependency 'cocoapods', '~> 1.5'
+  spec.add_dependency 'logger'
   spec.add_dependency 'mustache', '~> 1.1'
   spec.add_dependency 'open4', '~> 1.3'
   spec.add_dependency 'redcarpet', '~> 3.4'

--- a/lib/jazzy/source_declaration/type.rb
+++ b/lib/jazzy/source_declaration/type.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'logger'
 require 'active_support'
 require 'active_support/inflector'
 


### PR DESCRIPTION
Add `logger` require to work around external bug.
Add `logger` gem dependency to prep for Ruby 3.5.
Add explicit `activesupport` dependency that has been missing forever - conditions match cocoapods-core.

Fixes #1414 