### PR TITLE
Do not skip over empty Objective C categories.

### DIFF
--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -621,7 +621,8 @@ module Jazzy
         declaration.children = make_substructure(doc, declaration)
         next if declaration.type.extension? &&
                 declaration.children.empty? &&
-                !declaration.inherited_types?
+                !declaration.inherited_types? &&
+                !declaration.type.objc_category? # Don't discard empty Obj-C categories
 
         declarations << declaration
       end


### PR DESCRIPTION
## Background
For a header like below that just declares conformance for `UIScreen` with a protocol called `GMSNavigationScreenMetrics` based on properties that UIScreen already implements, Jazzy does not currently generate any documentation to indicate / declare this conformance:
```
/**
 * Protocol for returning information about screen metrics.
 *
 * This protocol is a subset of the screen-metric-related properties implemented by `UIScreen`.
 */
@protocol GMSNavigationScreenMetrics

/** The bounding rectangle of the screen, measured in points. */
@property(nonatomic, assign) CGRect bounds;

/** The bounding rectangle of the physical screen, measured in pixels.*/
@property(nonatomic, assign) CGRect nativeBounds;

/** The native scale factor for the physical screen. */
@property(nonatomic, assign) CGFloat nativeScale;

/** The natural scale factor associated with the screen. */
@property(nonatomic, assign) CGFloat scale;

@end

/**
 * `UIScreen` category already implements all the methods in the `GMSNavigationScreenMetrics`
 * protocol.
 */
@interface UIScreen (GMSNavigationStepImageOptions) <GMSNavigationScreenMetrics>
@end
```

If we explicitly add any members to this category, documentation is generated for `UIScreen(GMSNavigationStepImageOptions)` in the `Categories` section.

## Change Description
This PR forces empty Objective C categories to be documented by not skipping over declarations that are empty extensions if they have are of the type `objc_category`.

Please let me know if you:
* Think we should do this under an optional command line flag.
* Would recommend a different / more specific check.

Thanks!