### PR TITLE
Update apple theme demo location

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.1.0-beta'
+          xcode-version: '26.2'
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ of the modules being documented.
 
 Three themes are provided with jazzy: `apple` (default), `fullwidth` and `jony`.
 
-* `apple` example: <https://realm.io/docs/swift/latest/api/>
+* `apple` example: <https://johnfairh.github.io/demo-jazzy-apple-theme/>
 * `fullwidth` example: <https://reduxkit.github.io/ReduxKit/>
 * `jony` example: <https://harshilshah.github.io/IGListKit/>
 


### PR DESCRIPTION
Fixes #1427 

Move CI to Xcode 26.2, 26.1 beta no longer in the image